### PR TITLE
feat: 댓글 로직 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
 
+    testImplementation 'com.h2database:h2'
     testCompileOnly 'org.projectlombok:lombok' // 테스트 의존성 추가
     testAnnotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/com/threestar/trainus/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/threestar/trainus/domain/comment/controller/CommentController.java
@@ -1,4 +1,31 @@
 package com.threestar.trainus.domain.comment.controller;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.threestar.trainus.domain.comment.dto.CommentCreateRequestDto;
+import com.threestar.trainus.domain.comment.dto.CommentResponseDto;
+import com.threestar.trainus.domain.comment.service.CommentService;
+import com.threestar.trainus.global.unit.BaseResponse;
+
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
 public class CommentController {
+
+	private final CommentService commentService;
+
+	@PostMapping("/api/v1/comments/{lessonId}")
+	public ResponseEntity<BaseResponse<CommentResponseDto>> createComment(@PathVariable Long lessonId,
+		@RequestBody CommentCreateRequestDto request, HttpSession session) {
+		Long userId = (Long)session.getAttribute("user");
+		CommentResponseDto comment = commentService.createComment(request, lessonId, userId);
+		return BaseResponse.ok("댓글 등록 완료되었습니다", comment, HttpStatus.CREATED);
+	}
 }

--- a/src/main/java/com/threestar/trainus/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/threestar/trainus/domain/comment/controller/CommentController.java
@@ -37,8 +37,8 @@ public class CommentController {
 
 	@GetMapping("{lessonId}")
 	public ResponseEntity<BaseResponse<CommentPageResponseDto>> readAll(@PathVariable Long lessonId,
-		@RequestParam("page") Long page,
-		@RequestParam("pageSize") Long pageSize) {
+		@RequestParam("page") int page,
+		@RequestParam("pageSize") int pageSize) {
 		return BaseResponse.ok("댓글 조회 성공", commentService.readAll(lessonId, page, pageSize), HttpStatus.OK);
 	}
 

--- a/src/main/java/com/threestar/trainus/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/threestar/trainus/domain/comment/controller/CommentController.java
@@ -2,12 +2,15 @@ package com.threestar.trainus.domain.comment.controller;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.threestar.trainus.domain.comment.dto.CommentCreateRequestDto;
+import com.threestar.trainus.domain.comment.dto.CommentPageResponseDto;
 import com.threestar.trainus.domain.comment.dto.CommentResponseDto;
 import com.threestar.trainus.domain.comment.service.CommentService;
 import com.threestar.trainus.global.unit.BaseResponse;
@@ -24,8 +27,15 @@ public class CommentController {
 	@PostMapping("/api/v1/comments/{lessonId}")
 	public ResponseEntity<BaseResponse<CommentResponseDto>> createComment(@PathVariable Long lessonId,
 		@RequestBody CommentCreateRequestDto request, HttpSession session) {
-		Long userId = (Long)session.getAttribute("user");
+		Long userId = (Long)session.getAttribute("LOGIN_USER");
 		CommentResponseDto comment = commentService.createComment(request, lessonId, userId);
 		return BaseResponse.ok("댓글 등록 완료되었습니다", comment, HttpStatus.CREATED);
+	}
+
+	@GetMapping("/api/v1/comments/{lessonId}")
+	public ResponseEntity<BaseResponse<CommentPageResponseDto>> readAll(@PathVariable Long lessonId,
+		@RequestParam("page") Long page,
+		@RequestParam("pageSize") Long pageSize) {
+		return BaseResponse.ok("댓글 조회 성공", commentService.readAll(lessonId, page, pageSize), HttpStatus.OK);
 	}
 }

--- a/src/main/java/com/threestar/trainus/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/threestar/trainus/domain/comment/controller/CommentController.java
@@ -2,10 +2,12 @@ package com.threestar.trainus.domain.comment.controller;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -19,12 +21,13 @@ import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 
 @RestController
+@RequestMapping(("/api/v1/comments/"))
 @RequiredArgsConstructor
 public class CommentController {
 
 	private final CommentService commentService;
 
-	@PostMapping("/api/v1/comments/{lessonId}")
+	@PostMapping("{lessonId}")
 	public ResponseEntity<BaseResponse<CommentResponseDto>> createComment(@PathVariable Long lessonId,
 		@RequestBody CommentCreateRequestDto request, HttpSession session) {
 		Long userId = (Long)session.getAttribute("LOGIN_USER");
@@ -32,10 +35,17 @@ public class CommentController {
 		return BaseResponse.ok("댓글 등록 완료되었습니다", comment, HttpStatus.CREATED);
 	}
 
-	@GetMapping("/api/v1/comments/{lessonId}")
+	@GetMapping("{lessonId}")
 	public ResponseEntity<BaseResponse<CommentPageResponseDto>> readAll(@PathVariable Long lessonId,
 		@RequestParam("page") Long page,
 		@RequestParam("pageSize") Long pageSize) {
 		return BaseResponse.ok("댓글 조회 성공", commentService.readAll(lessonId, page, pageSize), HttpStatus.OK);
+	}
+
+	@DeleteMapping("{commentId}")
+	public ResponseEntity<BaseResponse<Void>> deleteComment(@PathVariable Long commentId, HttpSession session) {
+		Long userId = (Long)session.getAttribute("LOGIN_USER");
+		commentService.delete(commentId, userId);
+		return BaseResponse.ok("댓글이 삭제되었습니다", null, HttpStatus.NO_CONTENT);
 	}
 }

--- a/src/main/java/com/threestar/trainus/domain/comment/dto/CommentCreateRequestDto.java
+++ b/src/main/java/com/threestar/trainus/domain/comment/dto/CommentCreateRequestDto.java
@@ -1,4 +1,9 @@
 package com.threestar.trainus.domain.comment.dto;
 
+import lombok.Getter;
+
+@Getter
 public class CommentCreateRequestDto {
+	private String content;
+	private Long parentCommentId;
 }

--- a/src/main/java/com/threestar/trainus/domain/comment/dto/CommentCreateRequestDto.java
+++ b/src/main/java/com/threestar/trainus/domain/comment/dto/CommentCreateRequestDto.java
@@ -1,4 +1,4 @@
 package com.threestar.trainus.domain.comment.dto;
 
-public class CommentDto {
+public class CommentCreateRequestDto {
 }

--- a/src/main/java/com/threestar/trainus/domain/comment/dto/CommentCreateRequestDto.java
+++ b/src/main/java/com/threestar/trainus/domain/comment/dto/CommentCreateRequestDto.java
@@ -1,8 +1,8 @@
 package com.threestar.trainus.domain.comment.dto;
 
-import lombok.Getter;
+import lombok.Data;
 
-@Getter
+@Data
 public class CommentCreateRequestDto {
 	private String content;
 	private Long parentCommentId;

--- a/src/main/java/com/threestar/trainus/domain/comment/dto/CommentPageResponseDto.java
+++ b/src/main/java/com/threestar/trainus/domain/comment/dto/CommentPageResponseDto.java
@@ -1,0 +1,14 @@
+package com.threestar.trainus.domain.comment.dto;
+
+import java.util.List;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CommentPageResponseDto {
+
+	private List<CommentResponseDto> comments;
+	private Long commentCount;
+}

--- a/src/main/java/com/threestar/trainus/domain/comment/dto/CommentResponseDto.java
+++ b/src/main/java/com/threestar/trainus/domain/comment/dto/CommentResponseDto.java
@@ -1,0 +1,17 @@
+package com.threestar.trainus.domain.comment.dto;
+
+import java.time.LocalDateTime;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CommentResponseDto {
+	private Long commentId;
+	private Long userId;
+	private String content;
+	private Long parentCommentId;
+	private Boolean deleted;
+	private LocalDateTime createdAt;
+}

--- a/src/main/java/com/threestar/trainus/domain/comment/entity/Comment.java
+++ b/src/main/java/com/threestar/trainus/domain/comment/entity/Comment.java
@@ -16,10 +16,12 @@ import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Table(name = "comments")
 @Entity
+@Getter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/threestar/trainus/domain/comment/entity/Comment.java
+++ b/src/main/java/com/threestar/trainus/domain/comment/entity/Comment.java
@@ -52,4 +52,7 @@ public class Comment extends BaseDateEntity {
 		return parentCommentId.longValue() == commentId;
 	}
 
+	public void delete() {
+		deleted = true;
+	}
 }

--- a/src/main/java/com/threestar/trainus/domain/comment/entity/Comment.java
+++ b/src/main/java/com/threestar/trainus/domain/comment/entity/Comment.java
@@ -46,4 +46,7 @@ public class Comment extends BaseDateEntity {
 	@Column(nullable = false)
 	private Boolean deleted;
 
+	public boolean isRoot() {
+		return parentCommentId.longValue() == commentId;
+	}
 }

--- a/src/main/java/com/threestar/trainus/domain/comment/entity/Comment.java
+++ b/src/main/java/com/threestar/trainus/domain/comment/entity/Comment.java
@@ -18,6 +18,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Table(name = "comments")
 @Entity
@@ -41,6 +42,7 @@ public class Comment extends BaseDateEntity {
 	@Column(length = 50, nullable = false)
 	private String content;
 
+	@Setter
 	private Long parentCommentId;
 
 	@Column(nullable = false)
@@ -49,4 +51,5 @@ public class Comment extends BaseDateEntity {
 	public boolean isRoot() {
 		return parentCommentId.longValue() == commentId;
 	}
+
 }

--- a/src/main/java/com/threestar/trainus/domain/comment/mapper/CommentMapper.java
+++ b/src/main/java/com/threestar/trainus/domain/comment/mapper/CommentMapper.java
@@ -22,7 +22,7 @@ public class CommentMapper {
 			.build();
 	}
 
-	public static CommentPageResponseDto toCommentPageResponseDto(List<CommentResponseDto> comments, long count) {
+	public static CommentPageResponseDto toCommentPageResponseDto(List<CommentResponseDto> comments, Long count) {
 		return CommentPageResponseDto.builder()
 			.comments(comments)
 			.commentCount(count)

--- a/src/main/java/com/threestar/trainus/domain/comment/mapper/CommentMapper.java
+++ b/src/main/java/com/threestar/trainus/domain/comment/mapper/CommentMapper.java
@@ -1,4 +1,31 @@
 package com.threestar.trainus.domain.comment.mapper;
 
+import java.util.List;
+
+import com.threestar.trainus.domain.comment.dto.CommentPageResponseDto;
+import com.threestar.trainus.domain.comment.dto.CommentResponseDto;
+import com.threestar.trainus.domain.comment.entity.Comment;
+
 public class CommentMapper {
+
+	private CommentMapper() {
+	}
+
+	public static CommentResponseDto toCommentResponseDto(Comment comment) {
+		return CommentResponseDto.builder()
+			.commentId(comment.getCommentId())
+			.userId(comment.getUser().getId())
+			.content(comment.getContent())
+			.parentCommentId(comment.getParentCommentId())
+			.deleted(comment.getDeleted())
+			.createdAt(comment.getCreatedAt())
+			.build();
+	}
+
+	public static CommentPageResponseDto toCommentPageResponseDto(List<CommentResponseDto> comments, long count) {
+		return CommentPageResponseDto.builder()
+			.comments(comments)
+			.commentCount(count)
+			.build();
+	}
 }

--- a/src/main/java/com/threestar/trainus/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/threestar/trainus/domain/comment/repository/CommentRepository.java
@@ -1,8 +1,39 @@
 package com.threestar.trainus.domain.comment.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.threestar.trainus.domain.comment.entity.Comment;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+	@Query(
+		value = "select comments.comment_id, comments.lesson_id, comments.user_id, comments.content,"
+			+ " comments.parent_comment_id, comments.deleted, comments.created_at, comments.updated_at "
+			+ " from ("
+			+ "	select comment_id from comments where lesson_id = :lessonId "
+			+ " order by parent_comment_id asc, comment_id asc "
+			+ " limit :limit offset :offset "
+			+ ") t left join comments on t.comment_id = comments.comment_id",
+		nativeQuery = true
+	)
+	List<Comment> findAll(
+		@Param("lessonId") Long lessonId,
+		@Param("offset") Long offset,
+		@Param("limit") Long limit
+	);
+
+	@Query(
+		value = "select count(*) from ("
+		+ " select comment_id from comments where lesson_id = :lessonId limit :limit"
+		+ ") t",
+		nativeQuery = true
+	)
+	Long count(
+		@Param("lessonId") Long lessonId,
+		@Param("limit") Long limit
+	);
 }

--- a/src/main/java/com/threestar/trainus/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/threestar/trainus/domain/comment/repository/CommentRepository.java
@@ -1,4 +1,8 @@
 package com.threestar.trainus.domain.comment.repository;
 
-public interface CommentRepository {
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.threestar.trainus.domain.comment.entity.Comment;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
 }

--- a/src/main/java/com/threestar/trainus/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/threestar/trainus/domain/comment/repository/CommentRepository.java
@@ -23,8 +23,8 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 	)
 	List<Comment> findAll(
 		@Param("lessonId") Long lessonId,
-		@Param("offset") Long offset,
-		@Param("limit") Long limit
+		@Param("offset") int offset,
+		@Param("limit") int limit
 	);
 
 	@Query(
@@ -35,7 +35,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 	)
 	Long count(
 		@Param("lessonId") Long lessonId,
-		@Param("limit") Long limit
+		@Param("limit") int limit
 	);
 
 	@Query(
@@ -49,7 +49,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 	Long countBy(
 		@Param("lessonId") Long lessonId,
 		@Param("parentCommentId") Long parentCommentId,
-		@Param("limit") Long limit
+		@Param("limit") int limit
 	);
 
 	Optional<Comment> findByCommentIdAndUserId(Long commentId, Long userId);

--- a/src/main/java/com/threestar/trainus/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/threestar/trainus/domain/comment/repository/CommentRepository.java
@@ -1,6 +1,7 @@
 package com.threestar.trainus.domain.comment.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -28,12 +29,29 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
 	@Query(
 		value = "select count(*) from ("
-		+ " select comment_id from comments where lesson_id = :lessonId limit :limit"
-		+ ") t",
+			+ " select comment_id from comments where lesson_id = :lessonId limit :limit"
+			+ ") t",
 		nativeQuery = true
 	)
 	Long count(
 		@Param("lessonId") Long lessonId,
 		@Param("limit") Long limit
 	);
+
+	@Query(
+		value = "select count(*) from ("
+			+ " select comment_id from comments"
+			+ " where lesson_id = :lessonId and parent_comment_id = :parentCommentId"
+			+ " limit :limit"
+			+ ") t",
+		nativeQuery = true
+	)
+	Long countBy(
+		@Param("lessonId") Long lessonId,
+		@Param("parentCommentId") Long parentCommentId,
+		@Param("limit") Long limit
+	);
+
+	Optional<Comment> findByCommentIdAndUserId(Long commentId, Long userId);
+
 }

--- a/src/main/java/com/threestar/trainus/domain/comment/service/CommentService.java
+++ b/src/main/java/com/threestar/trainus/domain/comment/service/CommentService.java
@@ -1,4 +1,60 @@
 package com.threestar.trainus.domain.comment.service;
 
+import static java.util.function.Predicate.*;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.threestar.trainus.domain.comment.dto.CommentCreateRequestDto;
+import com.threestar.trainus.domain.comment.dto.CommentResponseDto;
+import com.threestar.trainus.domain.comment.entity.Comment;
+import com.threestar.trainus.domain.comment.mapper.CommentMapper;
+import com.threestar.trainus.domain.comment.repository.CommentRepository;
+import com.threestar.trainus.domain.lesson.admin.entity.Lesson;
+import com.threestar.trainus.domain.lesson.admin.repository.LessonRepository;
+import com.threestar.trainus.domain.user.entity.User;
+import com.threestar.trainus.domain.user.repository.UserRepository;
+import com.threestar.trainus.global.exception.domain.ErrorCode;
+import com.threestar.trainus.global.exception.handler.BusinessException;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
 public class CommentService {
+
+	private final UserRepository userRepository;
+	private final LessonRepository lessonRepository;
+	private final CommentRepository commentRepository;
+
+	@Transactional
+	public CommentResponseDto createComment(CommentCreateRequestDto request, Long lessonId, Long userId) {
+		Lesson findLesson = lessonRepository.findById(lessonId)
+			.orElseThrow(() -> new BusinessException(ErrorCode.LESSON_NOT_FOUND));
+		User findUser = userRepository.findById(userId)
+			.orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+		Comment parent = findParent(request);
+		Comment newComment = commentRepository.save(
+			Comment.builder()
+				.lesson(findLesson)
+				.user(findUser)
+				.deleted(false)
+				.content(request.getContent())
+				.parentCommentId(parent == null ? null : parent.getCommentId())
+				.build()
+		);
+		return CommentMapper.toCommentResponseDto(newComment);
+	}
+
+	private Comment findParent(CommentCreateRequestDto request) {
+		Long parentCommentId = request.getParentCommentId();
+		if (parentCommentId == null) {
+			return null;
+		}
+		return commentRepository.findById(parentCommentId)
+			.filter(not(Comment::getDeleted))
+			.filter(Comment::isRoot)
+			.orElseThrow();
+	}
+
 }

--- a/src/main/java/com/threestar/trainus/domain/comment/service/CommentService.java
+++ b/src/main/java/com/threestar/trainus/domain/comment/service/CommentService.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.threestar.trainus.domain.comment.dto.CommentCreateRequestDto;
+import com.threestar.trainus.domain.comment.dto.CommentPageResponseDto;
 import com.threestar.trainus.domain.comment.dto.CommentResponseDto;
 import com.threestar.trainus.domain.comment.entity.Comment;
 import com.threestar.trainus.domain.comment.mapper.CommentMapper;
@@ -16,6 +17,7 @@ import com.threestar.trainus.domain.user.entity.User;
 import com.threestar.trainus.domain.user.repository.UserRepository;
 import com.threestar.trainus.global.exception.domain.ErrorCode;
 import com.threestar.trainus.global.exception.handler.BusinessException;
+import com.threestar.trainus.global.utils.PageLimitCalculator;
 
 import lombok.RequiredArgsConstructor;
 
@@ -34,15 +36,21 @@ public class CommentService {
 		User findUser = userRepository.findById(userId)
 			.orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 		Comment parent = findParent(request);
-		Comment newComment = commentRepository.save(
-			Comment.builder()
-				.lesson(findLesson)
-				.user(findUser)
-				.deleted(false)
-				.content(request.getContent())
-				.parentCommentId(parent == null ? null : parent.getCommentId())
-				.build()
-		);
+
+		Comment newComment = Comment.builder()
+			.lesson(findLesson)
+			.user(findUser)
+			.deleted(false)
+			.content(request.getContent())
+			.build();
+
+		commentRepository.saveAndFlush(newComment); //즉시 저장을 통해 commentId
+
+		if (parent == null) {
+			newComment.setParentCommentId(newComment.getCommentId());
+		} else {
+			newComment.setParentCommentId(parent.getCommentId());
+		}
 		return CommentMapper.toCommentResponseDto(newComment);
 	}
 
@@ -55,6 +63,17 @@ public class CommentService {
 			.filter(not(Comment::getDeleted))
 			.filter(Comment::isRoot)
 			.orElseThrow();
+	}
+
+	@Transactional(readOnly = true)
+	public CommentPageResponseDto readAll(Long lessonId, Long page, Long pageSize) {
+		return CommentMapper.toCommentPageResponseDto(
+			commentRepository.findAll(lessonId, (page - 1) * pageSize, pageSize)
+				.stream().map(CommentMapper::toCommentResponseDto)
+				.toList(),
+			commentRepository.count(lessonId, PageLimitCalculator.calculatePageLimit(page, pageSize, 5L))
+			//한번에 보일 수 있는 페이지 이동 갯수 5개(프론트와 협의)
+		);
 	}
 
 }

--- a/src/main/java/com/threestar/trainus/domain/comment/service/CommentService.java
+++ b/src/main/java/com/threestar/trainus/domain/comment/service/CommentService.java
@@ -66,12 +66,12 @@ public class CommentService {
 	}
 
 	@Transactional(readOnly = true)
-	public CommentPageResponseDto readAll(Long lessonId, Long page, Long pageSize) {
+	public CommentPageResponseDto readAll(Long lessonId, int page, int pageSize) {
 		return CommentMapper.toCommentPageResponseDto(
 			commentRepository.findAll(lessonId, (page - 1) * pageSize, pageSize)
 				.stream().map(CommentMapper::toCommentResponseDto)
 				.toList(),
-			commentRepository.count(lessonId, PageLimitCalculator.calculatePageLimit(page, pageSize, 5L))
+			commentRepository.count(lessonId, PageLimitCalculator.calculatePageLimit(page, pageSize, 5))
 			//한번에 보일 수 있는 페이지 이동 갯수 5개(프론트와 협의)
 		);
 	}
@@ -90,7 +90,7 @@ public class CommentService {
 	}
 
 	private boolean hasChildren(Comment comment) {
-		return commentRepository.countBy(comment.getLesson().getId(), comment.getCommentId(), 2L) == 2;
+		return commentRepository.countBy(comment.getLesson().getId(), comment.getCommentId(), 2) == 2;
 	}
 
 	private void delete(Comment comment) {

--- a/src/main/java/com/threestar/trainus/global/utils/PageLimitCalculator.java
+++ b/src/main/java/com/threestar/trainus/global/utils/PageLimitCalculator.java
@@ -1,0 +1,12 @@
+package com.threestar.trainus.global.utils;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class PageLimitCalculator {
+
+	public static Long calculatePageLimit(Long page, Long pageSize, Long movablePageCount) {
+		return (((page - 1) / movablePageCount) + 1) * pageSize * movablePageCount + 1;
+	}
+}

--- a/src/main/java/com/threestar/trainus/global/utils/PageLimitCalculator.java
+++ b/src/main/java/com/threestar/trainus/global/utils/PageLimitCalculator.java
@@ -6,7 +6,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class PageLimitCalculator {
 
-	public static Long calculatePageLimit(Long page, Long pageSize, Long movablePageCount) {
+	public static int calculatePageLimit(int page, int pageSize, int movablePageCount) {
 		return (((page - 1) / movablePageCount) + 1) * pageSize * movablePageCount + 1;
 	}
 }

--- a/src/test/java/com/threestar/trainus/TrainUsApplicationTests.java
+++ b/src/test/java/com/threestar/trainus/TrainUsApplicationTests.java
@@ -6,8 +6,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 @SpringBootTest
 class TrainUsApplicationTests {
 
-    @Test
-    void contextLoads() {
-    }
+	@Test
+	void contextLoads() {
+	}
 
 }


### PR DESCRIPTION
## 🛠️ 작업 내용
댓글 생성, 댓글 조회(페이징), 댓글 삭제 구현했습니다. 응답의 경우 노션에 수정해두었습니다. 프론트와 회의 후 반영하면 될 것 같습니다.

Body = {"status":200,"message":"댓글 조회 성공","data":{"comments":[{"commentId":1,"userId":1,"content":"댓글1","parentCommentId":1,"deleted":false,"createdAt":"2025-07-10T01:20:40.113759"},{"commentId":2,"userId":2,"content":"대댓글1","parentCommentId":1,"deleted":false,"createdAt":"2025-07-10T01:20:40.168393"},{"commentId":5,"userId":3,"content":"대댓글2","parentCommentId":1,"deleted":false,"createdAt":"2025-07-10T01:20:40.190891"},{"commentId":3,"userId":2,"content":"댓글2","parentCommentId":3,"deleted":false,"createdAt":"2025-07-10T01:20:40.176129"},{"commentId":4,"userId":3,"content":"대댓글2","parentCommentId":3,"deleted":false,"createdAt":"2025-07-10T01:20:40.183319"}],"commentCount":9}}


   
## ✅ PR 유형
- [x] 새로운 기능 추가
- [ ] CSS 등 사용자 UI 디자인 변경
- [x] 코드 리팩토링
- [ ] 파일 혹은 폴더명 수정

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?

## 🔗 관련 이슈
- #9 

## 💬 기타 참고 사항
-우선 테스트 코드는 아직 추가 안했습니다, securityConfig와 user엔티티에서 table명이 그냥 user인 경우에는 자꾸 에러가 나서 users로 바꾸면 올바르게 동작합니다..