### PR TITLE
feat: 프로필/메타데이터/퍼사드 패턴 구현

### DIFF
--- a/src/main/java/com/threestar/trainus/domain/metadata/dto/ProfileMetadataResponseDto.java
+++ b/src/main/java/com/threestar/trainus/domain/metadata/dto/ProfileMetadataResponseDto.java
@@ -1,0 +1,8 @@
+package com.threestar.trainus.domain.metadata.dto;
+
+public record ProfileMetadataResponseDto(
+	Long userId,
+	Integer reviewCount,
+	Float rating
+) {
+}

--- a/src/main/java/com/threestar/trainus/domain/metadata/entity/ProfileMetadata.java
+++ b/src/main/java/com/threestar/trainus/domain/metadata/entity/ProfileMetadata.java
@@ -1,16 +1,41 @@
 package com.threestar.trainus.domain.metadata.entity;
 
+import com.threestar.trainus.domain.user.entity.User;
+
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
+@Table(name = "profile_metadata")
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ProfileMetadata {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
+
+	@OneToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id", nullable = false)
+	private User user;
+
+	@Column(nullable = false, columnDefinition = "INT DEFAULT 0")
+	private Integer reviewCount;
+
+	@Column(nullable = false, columnDefinition = "FLOAT DEFAULT 0.0")
+	private Float rating;
 }

--- a/src/main/java/com/threestar/trainus/domain/metadata/entity/ProfileMetadata.java
+++ b/src/main/java/com/threestar/trainus/domain/metadata/entity/ProfileMetadata.java
@@ -33,9 +33,9 @@ public class ProfileMetadata {
 	@JoinColumn(name = "user_id", nullable = false)
 	private User user;
 
-	@Column(nullable = false, columnDefinition = "INT DEFAULT 0")
+	@Column(nullable = false)
 	private Integer reviewCount;
 
-	@Column(nullable = false, columnDefinition = "FLOAT DEFAULT 0.0")
+	@Column(nullable = false)
 	private Float rating;
 }

--- a/src/main/java/com/threestar/trainus/domain/metadata/mapper/ProfileMetadataMapper.java
+++ b/src/main/java/com/threestar/trainus/domain/metadata/mapper/ProfileMetadataMapper.java
@@ -1,0 +1,29 @@
+package com.threestar.trainus.domain.metadata.mapper;
+
+import com.threestar.trainus.domain.metadata.dto.ProfileMetadataResponseDto;
+import com.threestar.trainus.domain.metadata.entity.ProfileMetadata;
+import com.threestar.trainus.domain.metadata.repositroy.ProfileMetadataRepository;
+import com.threestar.trainus.domain.user.entity.User;
+
+public class ProfileMetadataMapper {
+
+	private ProfileMetadataMapper() {
+	}
+
+	public static ProfileMetadataResponseDto toResponseDto(ProfileMetadata profileMetadata, User user) {
+		return new ProfileMetadataResponseDto(
+			user.getId(),
+			profileMetadata.getReviewCount(),
+			profileMetadata.getRating()
+		);
+	}
+
+	public static ProfileMetadata toDefaultEntity(User user) {
+		return ProfileMetadata.builder()
+			.user(user)
+			.reviewCount(0)
+			.rating(0.0F)
+			.build();
+	}
+}
+

--- a/src/main/java/com/threestar/trainus/domain/metadata/mapper/ProfileMetadataMapper.java
+++ b/src/main/java/com/threestar/trainus/domain/metadata/mapper/ProfileMetadataMapper.java
@@ -2,7 +2,6 @@ package com.threestar.trainus.domain.metadata.mapper;
 
 import com.threestar.trainus.domain.metadata.dto.ProfileMetadataResponseDto;
 import com.threestar.trainus.domain.metadata.entity.ProfileMetadata;
-import com.threestar.trainus.domain.metadata.repositroy.ProfileMetadataRepository;
 import com.threestar.trainus.domain.user.entity.User;
 
 public class ProfileMetadataMapper {

--- a/src/main/java/com/threestar/trainus/domain/metadata/repository/ProfileMetadataRepository.java
+++ b/src/main/java/com/threestar/trainus/domain/metadata/repository/ProfileMetadataRepository.java
@@ -1,4 +1,4 @@
-package com.threestar.trainus.domain.metadata.repositroy;
+package com.threestar.trainus.domain.metadata.repository;
 
 import java.util.Optional;
 

--- a/src/main/java/com/threestar/trainus/domain/metadata/repositroy/ProfileMetadataRepository.java
+++ b/src/main/java/com/threestar/trainus/domain/metadata/repositroy/ProfileMetadataRepository.java
@@ -1,4 +1,12 @@
 package com.threestar.trainus.domain.metadata.repositroy;
 
-public interface ProfileMetadataRepository {
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.threestar.trainus.domain.metadata.entity.ProfileMetadata;
+
+public interface ProfileMetadataRepository extends JpaRepository<ProfileMetadata, Long> {
+
+	Optional<ProfileMetadata> findByUserId(Long userId);
 }

--- a/src/main/java/com/threestar/trainus/domain/metadata/service/ProfileMetadataService.java
+++ b/src/main/java/com/threestar/trainus/domain/metadata/service/ProfileMetadataService.java
@@ -1,4 +1,40 @@
 package com.threestar.trainus.domain.metadata.service;
 
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.threestar.trainus.domain.metadata.dto.ProfileMetadataResponseDto;
+import com.threestar.trainus.domain.metadata.entity.ProfileMetadata;
+import com.threestar.trainus.domain.metadata.mapper.ProfileMetadataMapper;
+import com.threestar.trainus.domain.metadata.repositroy.ProfileMetadataRepository;
+import com.threestar.trainus.domain.user.entity.User;
+import com.threestar.trainus.domain.user.repository.UserRepository;
+import com.threestar.trainus.global.exception.domain.ErrorCode;
+import com.threestar.trainus.global.exception.handler.BusinessException;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
 public class ProfileMetadataService {
+
+	private final ProfileMetadataRepository profileMetadataRepository;
+	private final UserRepository userRepository;
+
+	@Transactional
+	public void createDefaultMetadata(User user) {
+		ProfileMetadata defaultMetadata = ProfileMetadataMapper.toDefaultEntity(user);
+		profileMetadataRepository.save(defaultMetadata);
+	}
+
+	@Transactional(readOnly = true)
+	public ProfileMetadataResponseDto getMetadata(Long userId) {
+		User user = userRepository.findById(userId)
+			.orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+		ProfileMetadata profileMetadata = profileMetadataRepository.findByUserId(userId)
+			.orElseThrow(() -> new BusinessException(ErrorCode.METADATA_NOT_FOUND));
+
+		return ProfileMetadataMapper.toResponseDto(profileMetadata, user);
+	}
 }

--- a/src/main/java/com/threestar/trainus/domain/metadata/service/ProfileMetadataService.java
+++ b/src/main/java/com/threestar/trainus/domain/metadata/service/ProfileMetadataService.java
@@ -6,7 +6,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.threestar.trainus.domain.metadata.dto.ProfileMetadataResponseDto;
 import com.threestar.trainus.domain.metadata.entity.ProfileMetadata;
 import com.threestar.trainus.domain.metadata.mapper.ProfileMetadataMapper;
-import com.threestar.trainus.domain.metadata.repositroy.ProfileMetadataRepository;
+import com.threestar.trainus.domain.metadata.repository.ProfileMetadataRepository;
 import com.threestar.trainus.domain.user.entity.User;
 import com.threestar.trainus.domain.user.repository.UserRepository;
 import com.threestar.trainus.global.exception.domain.ErrorCode;

--- a/src/main/java/com/threestar/trainus/domain/profile/controller/ProfileController.java
+++ b/src/main/java/com/threestar/trainus/domain/profile/controller/ProfileController.java
@@ -13,7 +13,6 @@ import com.threestar.trainus.domain.profile.dto.ProfileDetailResponseDto;
 import com.threestar.trainus.domain.profile.dto.ProfileResponseDto;
 import com.threestar.trainus.domain.profile.dto.ProfileUpdateRequestDto;
 import com.threestar.trainus.domain.profile.service.ProfileFacadeService;
-import com.threestar.trainus.domain.profile.service.ProfileService;
 import com.threestar.trainus.global.unit.BaseResponse;
 
 import jakarta.servlet.http.HttpSession;
@@ -25,15 +24,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class ProfileController {
 
-	private final ProfileService profileService;
 	private final ProfileFacadeService facadeService;
-	@GetMapping("/{userId}")
-	public ResponseEntity<BaseResponse<ProfileResponseDto>> getProfile(
-		@PathVariable Long userId
-	) {
-		ProfileResponseDto response = profileService.getProfile(userId);
-		return BaseResponse.ok("프로필 조회가 완료되었습니다.", response, HttpStatus.OK);
-	}
 
 	@PatchMapping
 	public ResponseEntity<BaseResponse<ProfileResponseDto>> updateProfile(
@@ -41,11 +32,11 @@ public class ProfileController {
 		HttpSession session
 	) {
 		Long userId = (Long)session.getAttribute("LOGIN_USER");
-		ProfileResponseDto response = profileService.updateProfile(userId, requestDto);
+		ProfileResponseDto response = facadeService.updateProfile(userId, requestDto);
 		return BaseResponse.ok("프로필 수정이 완료되었습니다.", response, HttpStatus.OK);
 	}
 
-	@GetMapping("{userId}/detail")
+	@GetMapping("{userId}")
 	public ResponseEntity<BaseResponse<ProfileDetailResponseDto>> getProfileDetail(
 		@PathVariable Long userId
 	) {

--- a/src/main/java/com/threestar/trainus/domain/profile/controller/ProfileController.java
+++ b/src/main/java/com/threestar/trainus/domain/profile/controller/ProfileController.java
@@ -9,8 +9,10 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.threestar.trainus.domain.profile.dto.ProfileDetailResponseDto;
 import com.threestar.trainus.domain.profile.dto.ProfileResponseDto;
 import com.threestar.trainus.domain.profile.dto.ProfileUpdateRequestDto;
+import com.threestar.trainus.domain.profile.service.ProfileFacadeService;
 import com.threestar.trainus.domain.profile.service.ProfileService;
 import com.threestar.trainus.global.unit.BaseResponse;
 
@@ -24,7 +26,7 @@ import lombok.RequiredArgsConstructor;
 public class ProfileController {
 
 	private final ProfileService profileService;
-
+	private final ProfileFacadeService facadeService;
 	@GetMapping("/{userId}")
 	public ResponseEntity<BaseResponse<ProfileResponseDto>> getProfile(
 		@PathVariable Long userId
@@ -41,5 +43,13 @@ public class ProfileController {
 		Long userId = (Long)session.getAttribute("LOGIN_USER");
 		ProfileResponseDto response = profileService.updateProfile(userId, requestDto);
 		return BaseResponse.ok("프로필 수정이 완료되었습니다.", response, HttpStatus.OK);
+	}
+
+	@GetMapping("{userId}/detail")
+	public ResponseEntity<BaseResponse<ProfileDetailResponseDto>> getProfileDetail(
+		@PathVariable Long userId
+	) {
+		ProfileDetailResponseDto response = facadeService.getProfileDetail(userId);
+		return BaseResponse.ok("프로필 상세 조회가 완료되었습니다.", response, HttpStatus.OK);
 	}
 }

--- a/src/main/java/com/threestar/trainus/domain/profile/controller/ProfileController.java
+++ b/src/main/java/com/threestar/trainus/domain/profile/controller/ProfileController.java
@@ -26,6 +26,14 @@ public class ProfileController {
 
 	private final ProfileFacadeService facadeService;
 
+	@GetMapping("{userId}")
+	public ResponseEntity<BaseResponse<ProfileDetailResponseDto>> getProfileDetail(
+		@PathVariable Long userId
+	) {
+		ProfileDetailResponseDto response = facadeService.getProfileDetail(userId);
+		return BaseResponse.ok("프로필 상세 조회가 완료되었습니다.", response, HttpStatus.OK);
+	}
+
 	@PatchMapping
 	public ResponseEntity<BaseResponse<ProfileResponseDto>> updateProfile(
 		@Valid @RequestBody ProfileUpdateRequestDto requestDto,
@@ -34,13 +42,5 @@ public class ProfileController {
 		Long userId = (Long)session.getAttribute("LOGIN_USER");
 		ProfileResponseDto response = facadeService.updateProfile(userId, requestDto);
 		return BaseResponse.ok("프로필 수정이 완료되었습니다.", response, HttpStatus.OK);
-	}
-
-	@GetMapping("{userId}")
-	public ResponseEntity<BaseResponse<ProfileDetailResponseDto>> getProfileDetail(
-		@PathVariable Long userId
-	) {
-		ProfileDetailResponseDto response = facadeService.getProfileDetail(userId);
-		return BaseResponse.ok("프로필 상세 조회가 완료되었습니다.", response, HttpStatus.OK);
 	}
 }

--- a/src/main/java/com/threestar/trainus/domain/profile/controller/ProfileController.java
+++ b/src/main/java/com/threestar/trainus/domain/profile/controller/ProfileController.java
@@ -1,4 +1,45 @@
 package com.threestar.trainus.domain.profile.controller;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.threestar.trainus.domain.profile.dto.ProfileResponseDto;
+import com.threestar.trainus.domain.profile.dto.ProfileUpdateRequestDto;
+import com.threestar.trainus.domain.profile.service.ProfileService;
+import com.threestar.trainus.global.unit.BaseResponse;
+
+import jakarta.servlet.http.HttpSession;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("api/v1/profiles")
+@RequiredArgsConstructor
 public class ProfileController {
+
+	private final ProfileService profileService;
+
+	@GetMapping("/{userId}")
+	public ResponseEntity<BaseResponse<ProfileResponseDto>> getProfile(
+		@PathVariable Long userId
+	) {
+		ProfileResponseDto response = profileService.getProfile(userId);
+		return BaseResponse.ok("프로필 조회가 완료되었습니다.", response, HttpStatus.OK);
+	}
+
+	@PatchMapping
+	public ResponseEntity<BaseResponse<ProfileResponseDto>> updateProfile(
+		@Valid @RequestBody ProfileUpdateRequestDto requestDto,
+		HttpSession session
+	) {
+		Long userId = (Long)session.getAttribute("LOGIN_USER");
+		ProfileResponseDto response = profileService.updateProfile(userId, requestDto);
+		return BaseResponse.ok("프로필 수정이 완료되었습니다.", response, HttpStatus.OK);
+	}
 }

--- a/src/main/java/com/threestar/trainus/domain/profile/dto/ProfileDetailResponseDto.java
+++ b/src/main/java/com/threestar/trainus/domain/profile/dto/ProfileDetailResponseDto.java
@@ -1,0 +1,11 @@
+package com.threestar.trainus.domain.profile.dto;
+
+public record ProfileDetailResponseDto(
+	Long userId,
+	String nickname,
+	String profileImage,
+	String intro,
+	Integer reviewCount,
+	Float rating
+) {
+}

--- a/src/main/java/com/threestar/trainus/domain/profile/dto/ProfileResponseDto.java
+++ b/src/main/java/com/threestar/trainus/domain/profile/dto/ProfileResponseDto.java
@@ -1,0 +1,9 @@
+package com.threestar.trainus.domain.profile.dto;
+
+public record ProfileResponseDto(
+	Long userId,
+	String nickname,
+	String profileImage,
+	String intro
+) {
+}

--- a/src/main/java/com/threestar/trainus/domain/profile/dto/ProfileUpdateRequestDto.java
+++ b/src/main/java/com/threestar/trainus/domain/profile/dto/ProfileUpdateRequestDto.java
@@ -1,0 +1,13 @@
+package com.threestar.trainus.domain.profile.dto;
+
+import jakarta.validation.constraints.Size;
+
+public record ProfileUpdateRequestDto(
+
+	@Size(max = 255, message = "프로필 이미지 URL은 255자 이하여야 합니다.")
+	String profileImage,
+
+	@Size(max = 255, message = "자기소개는 255자 이하여야 합니다.")
+	String intro
+) {
+}

--- a/src/main/java/com/threestar/trainus/domain/profile/dto/ProfileUpdateRequestDto.java
+++ b/src/main/java/com/threestar/trainus/domain/profile/dto/ProfileUpdateRequestDto.java
@@ -1,10 +1,17 @@
 package com.threestar.trainus.domain.profile.dto;
 
+import org.hibernate.validator.constraints.URL;
+
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 public record ProfileUpdateRequestDto(
 
 	@Size(max = 255, message = "프로필 이미지 URL은 255자 이하여야 합니다.")
+	@Pattern(
+		regexp = "^$|^https?://[\\w\\-._~:/?#\\[\\]@!$&'()*+,;=%]+$",
+		message = "올바른 URL 형식이어야 합니다."
+	)
 	String profileImage,
 
 	@Size(max = 255, message = "자기소개는 255자 이하여야 합니다.")

--- a/src/main/java/com/threestar/trainus/domain/profile/dto/TempDto.java
+++ b/src/main/java/com/threestar/trainus/domain/profile/dto/TempDto.java
@@ -1,4 +1,0 @@
-package com.threestar.trainus.domain.profile.dto;
-
-public class TempDto {
-}

--- a/src/main/java/com/threestar/trainus/domain/profile/entity/Profile.java
+++ b/src/main/java/com/threestar/trainus/domain/profile/entity/Profile.java
@@ -38,12 +38,4 @@ public class Profile {
 
 	@Column(length = 255)
 	private String intro;
-
-	public static Profile createDefault(User user) {
-		return Profile.builder()
-			.user(user)
-			.profileImage(null)
-			.intro(null)
-			.build();
-	}
 }

--- a/src/main/java/com/threestar/trainus/domain/profile/entity/Profile.java
+++ b/src/main/java/com/threestar/trainus/domain/profile/entity/Profile.java
@@ -38,4 +38,9 @@ public class Profile {
 
 	@Column(length = 255)
 	private String intro;
+
+	public void updateProfile(String profileImage, String intro) {
+		this.profileImage = profileImage;
+		this.intro = intro;
+	}
 }

--- a/src/main/java/com/threestar/trainus/domain/profile/entity/Profile.java
+++ b/src/main/java/com/threestar/trainus/domain/profile/entity/Profile.java
@@ -11,11 +11,18 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
+@Builder
 @Getter
 @Table(name = "profile")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class Profile {
 
 	@Id
@@ -31,4 +38,12 @@ public class Profile {
 
 	@Column(length = 255)
 	private String intro;
+
+	public static Profile createDefault(User user) {
+		return Profile.builder()
+			.user(user)
+			.profileImage(null)
+			.intro(null)
+			.build();
+	}
 }

--- a/src/main/java/com/threestar/trainus/domain/profile/mapper/ProfileDetailMapper.java
+++ b/src/main/java/com/threestar/trainus/domain/profile/mapper/ProfileDetailMapper.java
@@ -10,7 +10,7 @@ public class ProfileDetailMapper {
 	private ProfileDetailMapper() {
 	}
 
-	public static ProfileDetailResponseDto combineToDetailDto(
+	public static ProfileDetailResponseDto toDetailResponseDto(
 		ProfileResponseDto profile,
 		ProfileMetadataResponseDto metadata
 	) {

--- a/src/main/java/com/threestar/trainus/domain/profile/mapper/ProfileDetailMapper.java
+++ b/src/main/java/com/threestar/trainus/domain/profile/mapper/ProfileDetailMapper.java
@@ -1,0 +1,26 @@
+package com.threestar.trainus.domain.profile.mapper;
+
+import com.threestar.trainus.domain.metadata.dto.ProfileMetadataResponseDto;
+import com.threestar.trainus.domain.profile.dto.ProfileDetailResponseDto;
+import com.threestar.trainus.domain.profile.dto.ProfileResponseDto;
+
+
+public class ProfileDetailMapper {
+
+	private ProfileDetailMapper() {
+	}
+
+	public static ProfileDetailResponseDto combineToDetailDto(
+		ProfileResponseDto profile,
+		ProfileMetadataResponseDto metadata
+	) {
+		return new ProfileDetailResponseDto(
+			profile.userId(),
+			profile.nickname(),
+			profile.profileImage(),
+			profile.intro(),
+			metadata.reviewCount(),
+			metadata.rating()
+		);
+	}
+}

--- a/src/main/java/com/threestar/trainus/domain/profile/mapper/ProfileMapper.java
+++ b/src/main/java/com/threestar/trainus/domain/profile/mapper/ProfileMapper.java
@@ -1,9 +1,6 @@
 package com.threestar.trainus.domain.profile.mapper;
 
-import com.threestar.trainus.domain.metadata.dto.ProfileMetadataResponseDto;
-import com.threestar.trainus.domain.profile.dto.ProfileDetailResponseDto;
 import com.threestar.trainus.domain.profile.dto.ProfileResponseDto;
-import com.threestar.trainus.domain.profile.dto.ProfileUpdateRequestDto;
 import com.threestar.trainus.domain.profile.entity.Profile;
 import com.threestar.trainus.domain.user.entity.User;
 
@@ -20,15 +17,6 @@ public class ProfileMapper {
 			profile.getProfileImage(),
 			profile.getIntro()
 		);
-	}
-
-	public static Profile toUpdateEntity(Profile profile, ProfileUpdateRequestDto requestDto) {
-		return Profile.builder()
-			.id(profile.getId())
-			.user(profile.getUser())
-			.profileImage(requestDto.profileImage())
-			.intro(requestDto.intro())
-			.build();
 	}
 
 	public static Profile toDefaultEntity(User user) {

--- a/src/main/java/com/threestar/trainus/domain/profile/mapper/ProfileMapper.java
+++ b/src/main/java/com/threestar/trainus/domain/profile/mapper/ProfileMapper.java
@@ -1,5 +1,7 @@
 package com.threestar.trainus.domain.profile.mapper;
 
+import com.threestar.trainus.domain.metadata.dto.ProfileMetadataResponseDto;
+import com.threestar.trainus.domain.profile.dto.ProfileDetailResponseDto;
 import com.threestar.trainus.domain.profile.dto.ProfileResponseDto;
 import com.threestar.trainus.domain.profile.dto.ProfileUpdateRequestDto;
 import com.threestar.trainus.domain.profile.entity.Profile;

--- a/src/main/java/com/threestar/trainus/domain/profile/mapper/ProfileMapper.java
+++ b/src/main/java/com/threestar/trainus/domain/profile/mapper/ProfileMapper.java
@@ -1,4 +1,31 @@
 package com.threestar.trainus.domain.profile.mapper;
 
+import com.threestar.trainus.domain.profile.dto.ProfileResponseDto;
+import com.threestar.trainus.domain.profile.dto.ProfileUpdateRequestDto;
+import com.threestar.trainus.domain.profile.entity.Profile;
+import com.threestar.trainus.domain.user.entity.User;
+
 public class ProfileMapper {
+
+	private ProfileMapper() {
+
+	}
+
+	public static ProfileResponseDto toResponseDto(Profile profile, User user) {
+		return new ProfileResponseDto(
+			user.getId(),
+			user.getNickname(),
+			profile.getProfileImage(),
+			profile.getIntro()
+		);
+	}
+
+	public static Profile toUpdateEntity(Profile profile, ProfileUpdateRequestDto requestDto) {
+		return Profile.builder()
+			.id(profile.getId())
+			.user(profile.getUser())
+			.profileImage(requestDto.profileImage())
+			.intro(requestDto.intro())
+			.build();
+	}
 }

--- a/src/main/java/com/threestar/trainus/domain/profile/mapper/ProfileMapper.java
+++ b/src/main/java/com/threestar/trainus/domain/profile/mapper/ProfileMapper.java
@@ -28,4 +28,12 @@ public class ProfileMapper {
 			.intro(requestDto.intro())
 			.build();
 	}
+
+	public static Profile toDefaultEntity(User user) {
+		return Profile.builder()
+			.user(user)
+			.profileImage(null)
+			.intro(null)
+			.build();
+	}
 }

--- a/src/main/java/com/threestar/trainus/domain/profile/repository/ProfileRepository.java
+++ b/src/main/java/com/threestar/trainus/domain/profile/repository/ProfileRepository.java
@@ -1,4 +1,12 @@
 package com.threestar.trainus.domain.profile.repository;
 
-public interface ProfileRepository {
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.threestar.trainus.domain.profile.entity.Profile;
+
+public interface ProfileRepository extends JpaRepository<Profile, Long> {
+
+	Optional<Profile> findByUserId(Long userId);
 }

--- a/src/main/java/com/threestar/trainus/domain/profile/service/ProfileFacadeService.java
+++ b/src/main/java/com/threestar/trainus/domain/profile/service/ProfileFacadeService.java
@@ -20,13 +20,13 @@ public class ProfileFacadeService {
 	private final ProfileService profileService;
 	private final ProfileMetadataService metadataService;
 
-	//프로필 상세 조회 (단순 프로필 + 메타데이터)
+	//프로필 상세 조회 (단순 프로필 + 메타데이터) 단순 프로필 조회는 제거.
 	@Transactional(readOnly = true)
 	public ProfileDetailResponseDto getProfileDetail(Long userId) {
 		ProfileResponseDto profile = profileService.getProfile(userId);
 		ProfileMetadataResponseDto metadata = metadataService.getMetadata(userId);
 
-		return ProfileDetailMapper.combineToDetailDto(profile, metadata);
+		return ProfileDetailMapper.toDetailResponseDto(profile, metadata);
 	}
 
 	//프로필 수정

--- a/src/main/java/com/threestar/trainus/domain/profile/service/ProfileFacadeService.java
+++ b/src/main/java/com/threestar/trainus/domain/profile/service/ProfileFacadeService.java
@@ -1,0 +1,31 @@
+package com.threestar.trainus.domain.profile.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.threestar.trainus.domain.metadata.dto.ProfileMetadataResponseDto;
+import com.threestar.trainus.domain.metadata.service.ProfileMetadataService;
+import com.threestar.trainus.domain.profile.dto.ProfileDetailResponseDto;
+import com.threestar.trainus.domain.profile.dto.ProfileResponseDto;
+import com.threestar.trainus.domain.profile.mapper.ProfileDetailMapper;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ProfileFacadeService {
+
+	private final ProfileService profileService;
+	private final ProfileMetadataService metadataService;
+
+	//프로필 dto랑 메타데이터 dto랑 합쳐서 응답을 내려주는 역할.
+	@Transactional
+	public ProfileDetailResponseDto getProfileDetail(Long userId) {
+
+		ProfileResponseDto profile = profileService.getProfile(userId);
+
+		ProfileMetadataResponseDto metadata = metadataService.getMetadata(userId);
+
+		return ProfileDetailMapper.combineToDetailDto(profile, metadata);
+	}
+}

--- a/src/main/java/com/threestar/trainus/domain/profile/service/ProfileFacadeService.java
+++ b/src/main/java/com/threestar/trainus/domain/profile/service/ProfileFacadeService.java
@@ -7,7 +7,9 @@ import com.threestar.trainus.domain.metadata.dto.ProfileMetadataResponseDto;
 import com.threestar.trainus.domain.metadata.service.ProfileMetadataService;
 import com.threestar.trainus.domain.profile.dto.ProfileDetailResponseDto;
 import com.threestar.trainus.domain.profile.dto.ProfileResponseDto;
+import com.threestar.trainus.domain.profile.dto.ProfileUpdateRequestDto;
 import com.threestar.trainus.domain.profile.mapper.ProfileDetailMapper;
+import com.threestar.trainus.domain.user.entity.User;
 
 import lombok.RequiredArgsConstructor;
 
@@ -18,14 +20,25 @@ public class ProfileFacadeService {
 	private final ProfileService profileService;
 	private final ProfileMetadataService metadataService;
 
-	//프로필 dto랑 메타데이터 dto랑 합쳐서 응답을 내려주는 역할.
-	@Transactional
+	//프로필 상세 조회 (단순 프로필 + 메타데이터)
+	@Transactional(readOnly = true)
 	public ProfileDetailResponseDto getProfileDetail(Long userId) {
-
 		ProfileResponseDto profile = profileService.getProfile(userId);
-
 		ProfileMetadataResponseDto metadata = metadataService.getMetadata(userId);
 
 		return ProfileDetailMapper.combineToDetailDto(profile, metadata);
+	}
+
+	//프로필 수정
+	@Transactional
+	public ProfileResponseDto updateProfile(Long userId, ProfileUpdateRequestDto requestDto) {
+		return profileService.updateProfile(userId, requestDto);
+	}
+
+	//회원가입 시 프로필,메타데이터 디폴트로 생성.
+	@Transactional
+	public void createDefaultProfile(User user) {
+		profileService.createDefaultProfile(user);
+		metadataService.createDefaultMetadata(user);
 	}
 }

--- a/src/main/java/com/threestar/trainus/domain/profile/service/ProfileService.java
+++ b/src/main/java/com/threestar/trainus/domain/profile/service/ProfileService.java
@@ -1,4 +1,56 @@
 package com.threestar.trainus.domain.profile.service;
 
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.threestar.trainus.domain.profile.dto.ProfileResponseDto;
+import com.threestar.trainus.domain.profile.dto.ProfileUpdateRequestDto;
+import com.threestar.trainus.domain.profile.entity.Profile;
+import com.threestar.trainus.domain.profile.mapper.ProfileMapper;
+import com.threestar.trainus.domain.profile.repository.ProfileRepository;
+import com.threestar.trainus.domain.user.entity.User;
+import com.threestar.trainus.domain.user.repository.UserRepository;
+import com.threestar.trainus.global.exception.domain.ErrorCode;
+import com.threestar.trainus.global.exception.handler.BusinessException;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
 public class ProfileService {
+
+	private final ProfileRepository profileRepository;
+	private final UserRepository userRepository;
+
+	@Transactional(readOnly = true)
+	public ProfileResponseDto getProfile(Long userId) {
+		User user = userRepository.findById(userId)
+			.orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+		Profile profile = profileRepository.findByUserId(userId)
+			.orElseThrow(() -> new BusinessException(ErrorCode.PROFILE_NOT_FOUND));
+
+		return ProfileMapper.toResponseDto(profile, user);
+	}
+
+	@Transactional
+	public ProfileResponseDto updateProfile(Long userId, ProfileUpdateRequestDto requestDto) {
+		User user = userRepository.findById(userId)
+			.orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+		Profile profile = profileRepository.findByUserId(userId)
+			.orElseThrow(() -> new BusinessException(ErrorCode.PROFILE_NOT_FOUND));
+
+		Profile updatedProfile = ProfileMapper.toUpdateEntity(profile, requestDto);
+
+		profileRepository.save(updatedProfile);
+
+		return ProfileMapper.toResponseDto(updatedProfile, user);
+	}
+
+	public void createDefaultProfile(User user) {
+		Profile defaultProfile = Profile.createDefault(user);
+		profileRepository.save(defaultProfile);
+	}
 }
+

--- a/src/main/java/com/threestar/trainus/domain/profile/service/ProfileService.java
+++ b/src/main/java/com/threestar/trainus/domain/profile/service/ProfileService.java
@@ -47,11 +47,9 @@ public class ProfileService {
 		Profile profile = profileRepository.findByUserId(userId)
 			.orElseThrow(() -> new BusinessException(ErrorCode.PROFILE_NOT_FOUND));
 
-		Profile updatedProfile = ProfileMapper.toUpdateEntity(profile, requestDto);
+		profile.updateProfile(requestDto.profileImage(), requestDto.intro());
 
-		profileRepository.save(updatedProfile);
-
-		return ProfileMapper.toResponseDto(updatedProfile, user);
+		return ProfileMapper.toResponseDto(profile, user);
 	}
 }
 

--- a/src/main/java/com/threestar/trainus/domain/profile/service/ProfileService.java
+++ b/src/main/java/com/threestar/trainus/domain/profile/service/ProfileService.java
@@ -22,6 +22,12 @@ public class ProfileService {
 	private final ProfileRepository profileRepository;
 	private final UserRepository userRepository;
 
+	@Transactional
+	public void createDefaultProfile(User user) {
+		Profile defaultProfile = ProfileMapper.toDefaultEntity(user);
+		profileRepository.save(defaultProfile);
+	}
+
 	@Transactional(readOnly = true)
 	public ProfileResponseDto getProfile(Long userId) {
 		User user = userRepository.findById(userId)
@@ -46,11 +52,6 @@ public class ProfileService {
 		profileRepository.save(updatedProfile);
 
 		return ProfileMapper.toResponseDto(updatedProfile, user);
-	}
-
-	public void createDefaultProfile(User user) {
-		Profile defaultProfile = Profile.createDefault(user);
-		profileRepository.save(defaultProfile);
 	}
 }
 

--- a/src/main/java/com/threestar/trainus/domain/user/controller/UserController.java
+++ b/src/main/java/com/threestar/trainus/domain/user/controller/UserController.java
@@ -19,10 +19,13 @@ import com.threestar.trainus.domain.user.service.EmailVerificationService;
 import com.threestar.trainus.domain.user.service.UserService;
 import com.threestar.trainus.global.unit.BaseResponse;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
+
+@Tag(name = "유저 API", description = "유저 API")
 @RestController
 @RequestMapping("/api/v1/users")
 @RequiredArgsConstructor

--- a/src/main/java/com/threestar/trainus/domain/user/service/UserService.java
+++ b/src/main/java/com/threestar/trainus/domain/user/service/UserService.java
@@ -4,6 +4,9 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.threestar.trainus.domain.profile.entity.Profile;
+import com.threestar.trainus.domain.profile.repository.ProfileRepository;
+import com.threestar.trainus.domain.profile.service.ProfileService;
 import com.threestar.trainus.domain.user.dto.LoginRequestDto;
 import com.threestar.trainus.domain.user.dto.LoginResponseDto;
 import com.threestar.trainus.domain.user.dto.NicknameCheckRequestDto;
@@ -24,6 +27,7 @@ public class UserService {
 
 	private final UserRepository userRepository;
 	private final PasswordEncoder passwordEncoder;
+	private final ProfileService profileService;
 
 	@Transactional
 	public SignupResponseDto signup(SignupRequestDto request) {
@@ -37,6 +41,8 @@ public class UserService {
 		String encodedPassword = passwordEncoder.encode(request.password());
 
 		User newUser = userRepository.save(UserMapper.toEntity(request, encodedPassword));
+
+		profileService.createDefaultProfile(newUser); //기본 프로필 생성.
 
 		return UserMapper.toSignupResponseDto(newUser);
 	}

--- a/src/main/java/com/threestar/trainus/domain/user/service/UserService.java
+++ b/src/main/java/com/threestar/trainus/domain/user/service/UserService.java
@@ -6,6 +6,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.threestar.trainus.domain.profile.entity.Profile;
 import com.threestar.trainus.domain.profile.repository.ProfileRepository;
+import com.threestar.trainus.domain.profile.service.ProfileFacadeService;
 import com.threestar.trainus.domain.profile.service.ProfileService;
 import com.threestar.trainus.domain.user.dto.LoginRequestDto;
 import com.threestar.trainus.domain.user.dto.LoginResponseDto;
@@ -27,7 +28,7 @@ public class UserService {
 
 	private final UserRepository userRepository;
 	private final PasswordEncoder passwordEncoder;
-	private final ProfileService profileService;
+	private final ProfileFacadeService facadeService;
 
 	@Transactional
 	public SignupResponseDto signup(SignupRequestDto request) {
@@ -42,7 +43,7 @@ public class UserService {
 
 		User newUser = userRepository.save(UserMapper.toEntity(request, encodedPassword));
 
-		profileService.createDefaultProfile(newUser); //기본 프로필 생성.
+		facadeService.createDefaultProfile(newUser); //기본 프로필 생성.
 
 		return UserMapper.toSignupResponseDto(newUser);
 	}

--- a/src/main/java/com/threestar/trainus/global/config/SecurityConfig.java
+++ b/src/main/java/com/threestar/trainus/global/config/SecurityConfig.java
@@ -19,7 +19,8 @@ public class SecurityConfig {
 	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 		http
 			.authorizeHttpRequests(auth -> auth
-				.requestMatchers("/api/v1/users/**", "/api/lessons/test-auth", "/swagger-ui/**", "/v3/api-docs/**")
+				.requestMatchers("/api/v1/users/**", "/api/lessons/test-auth", "/swagger-ui/**", "/v3/api-docs/**",
+					"/api/v1/profiles/**")
 				.permitAll()
 				.anyRequest()
 				.authenticated()

--- a/src/main/java/com/threestar/trainus/global/exception/domain/ErrorCode.java
+++ b/src/main/java/com/threestar/trainus/global/exception/domain/ErrorCode.java
@@ -37,7 +37,7 @@ public enum ErrorCode {
 	//404
 	COUPON_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 쿠폰을 찾을 수 없습니다."),
 	PROFILE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 프로필을 찾을 수 없습니다"),
-
+	METADATA_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 메타데이터를 찾을 수 없습니다"),
 	/*
 	 * Coupon : 예외처리
 	 */

--- a/src/main/java/com/threestar/trainus/global/exception/domain/ErrorCode.java
+++ b/src/main/java/com/threestar/trainus/global/exception/domain/ErrorCode.java
@@ -36,6 +36,7 @@ public enum ErrorCode {
 
 	//404
 	COUPON_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 쿠폰을 찾을 수 없습니다."),
+	PROFILE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 프로필을 찾을 수 없습니다"),
 
 	/*
 	 * Coupon : 예외처리

--- a/src/main/java/com/threestar/trainus/global/exception/domain/ErrorCode.java
+++ b/src/main/java/com/threestar/trainus/global/exception/domain/ErrorCode.java
@@ -36,8 +36,6 @@ public enum ErrorCode {
 
 	//404
 	COUPON_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 쿠폰을 찾을 수 없습니다."),
-	PROFILE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 프로필을 찾을 수 없습니다"),
-	METADATA_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 메타데이터를 찾을 수 없습니다"),
 	/*
 	 * Coupon : 예외처리
 	 */
@@ -60,7 +58,13 @@ public enum ErrorCode {
 	INVALID_VERIFICATION_CODE(HttpStatus.BAD_REQUEST, "유효하지 않은 인증 코드입니다."),
 	VERIFICATION_CODE_EXPIRED(HttpStatus.BAD_REQUEST, "인증 코드가 만료되었습니다."),
 	EMAIL_NOT_VERIFIED(HttpStatus.BAD_REQUEST, "이메일 인증이 완료되지 않았습니다."),
-	EMAIL_SEND_FAILED(HttpStatus.BAD_REQUEST, "이메일 발송을 실패했습니다.");
+	EMAIL_SEND_FAILED(HttpStatus.BAD_REQUEST, "이메일 발송을 실패했습니다."),
+
+	/*
+	 * Profile : 프로필 관련 예외처리
+	 */
+	PROFILE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 프로필을 찾을 수 없습니다"),
+	METADATA_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 메타데이터를 찾을 수 없습니다");
 	//마지막 세미콜론 명시 ;
 
 	private final HttpStatus status;


### PR DESCRIPTION
## 🛠️ 작업 내용
1. 프로필 조회 , 프로필 수정 기능 구현
2. 메타데이터 구현
3. Facade 패턴을 이용하여 프로필 서비스와 메타데이터 서비스를 조합한 통합 관리
  
<img width="786" height="324" alt="image" src="https://github.com/user-attachments/assets/5991e329-92c5-4194-a68a-abd40cf65007" />
<img width="735" height="312" alt="image" src="https://github.com/user-attachments/assets/74eed6bb-10b3-4df8-9dd5-4587965dfd59" />

퍼사드 패턴을 구현함에 따라
ProfileService: 프로필 CRUD 전담
ProfileMetadataService: 통계 데이터 관리 전담
ProfileFacadeService: 두 도메인 조합 및 복잡한 비즈니스 로직 처리

방식으로 관심사 분리 가능.
추후 추가되는 기능이 있을 시 퍼사드만 수정하면 된다.

- 아직 작은 규모의 프로젝트기에 Profile 도메인에 퍼사드를 도입했는데 추후 커지게 된다면 facade 도메인을 분리하는 게 좋아보임

## ✅ PR 유형
- [x] 새로운 기능 추가
- [ ] CSS 등 사용자 UI 디자인 변경
- [x] 코드 리팩토링
- [ ] 파일 혹은 폴더명 수정

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?

## 🔗 관련 이슈
#24 

## 💬 기타 참고 사항
