### PR TITLE
fix: 세션 인증 정보 SecurityContext에 주입

### DIFF
--- a/src/main/java/com/threestar/trainus/domain/user/controller/UserController.java
+++ b/src/main/java/com/threestar/trainus/domain/user/controller/UserController.java
@@ -5,6 +5,7 @@ import java.security.Principal;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -28,7 +29,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-
 
 @Tag(name = "유저 API", description = "유저 API")
 @RestController
@@ -79,7 +79,6 @@ public class UserController {
 		return BaseResponse.ok("인증 코드가 이메일로 발송되었습니다.", response, HttpStatus.OK);
 	}
 
-
 	@PostMapping("/verify/email-check")
 	public ResponseEntity<BaseResponse<Void>> confirmVerificationCode(
 		@Valid @RequestBody EmailVerificationDto request
@@ -90,25 +89,18 @@ public class UserController {
 
 	//SecurityContext에 잘 올라간 지 테스트
 	@GetMapping("/test-context")
-	public String testSecurityContext(Principal principal, HttpSession session) {
-		Long sessionUserId = (Long) session.getAttribute("LOGIN_USER");
+	public String testSecurityContext(@AuthenticationPrincipal Long userId, HttpSession session) {
+		Long sessionUserId = (Long)session.getAttribute("LOGIN_USER");
 
 		Authentication auth = SecurityContextHolder.getContext().getAuthentication();
 		Long contextUserId = null;
 		if (auth != null && auth.isAuthenticated() && !auth.getPrincipal().equals("anonymousUser")) {
-			contextUserId = (Long) auth.getPrincipal();
+			contextUserId = (Long)auth.getPrincipal();
 		}
 
-		Long principalUserId = null;
-		if (principal != null) {
-			try {
-				principalUserId = Long.valueOf(principal.getName());
-			} catch (NumberFormatException e) {
-				principalUserId = null;
-			}
-		}
+		Long principalUserId = userId;
 
-		return String.format("Session: %s, Context: %s, Principal: %s",
+		return String.format("Session: %s, Context: %s, AuthPrincipal: %s",
 			sessionUserId, contextUserId, principalUserId);
 	}
 }

--- a/src/main/java/com/threestar/trainus/domain/user/controller/UserController.java
+++ b/src/main/java/com/threestar/trainus/domain/user/controller/UserController.java
@@ -1,7 +1,12 @@
 package com.threestar.trainus.domain.user.controller;
 
+import java.security.Principal;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -81,5 +86,29 @@ public class UserController {
 	) {
 		emailVerificationService.verifyCode(request.email(), request.verificationCode());
 		return BaseResponse.ok("이메일 인증이 완료되었습니다.", null, HttpStatus.OK);
+	}
+
+	//SecurityContext에 잘 올라간 지 테스트
+	@GetMapping("/test-context")
+	public String testSecurityContext(Principal principal, HttpSession session) {
+		Long sessionUserId = (Long) session.getAttribute("LOGIN_USER");
+
+		Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+		Long contextUserId = null;
+		if (auth != null && auth.isAuthenticated() && !auth.getPrincipal().equals("anonymousUser")) {
+			contextUserId = (Long) auth.getPrincipal();
+		}
+
+		Long principalUserId = null;
+		if (principal != null) {
+			try {
+				principalUserId = Long.valueOf(principal.getName());
+			} catch (NumberFormatException e) {
+				principalUserId = null;
+			}
+		}
+
+		return String.format("Session: %s, Context: %s, Principal: %s",
+			sessionUserId, contextUserId, principalUserId);
 	}
 }

--- a/src/main/java/com/threestar/trainus/domain/user/service/UserService.java
+++ b/src/main/java/com/threestar/trainus/domain/user/service/UserService.java
@@ -1,5 +1,9 @@
 package com.threestar.trainus.domain.user.service;
 
+import java.util.Collections;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -60,11 +64,16 @@ public class UserService {
 
 		session.setAttribute("LOGIN_USER", user.getId());
 
+		UsernamePasswordAuthenticationToken authToken =
+			new UsernamePasswordAuthenticationToken(user.getId(), null, Collections.emptyList());
+		SecurityContextHolder.getContext().setAuthentication(authToken);
+
 		return UserMapper.toLoginResponseDto(user);
 	}
 
 	public void logout(HttpSession session) {
 		session.invalidate();
+		SecurityContextHolder.clearContext();
 	}
 
 	@Transactional(readOnly = true)

--- a/src/main/java/com/threestar/trainus/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/threestar/trainus/global/config/security/SecurityConfig.java
@@ -1,4 +1,4 @@
-package com.threestar.trainus.global.config;
+package com.threestar.trainus.global.config.security;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -6,9 +6,17 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import com.threestar.trainus.global.security.SessionAuthenticationFilter;
+
+import lombok.RequiredArgsConstructor;
 
 @Configuration
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+	private final SessionAuthenticationFilter sessionAuthenticationFilter;
 
 	@Bean
 	public PasswordEncoder passwordEncoder() {
@@ -25,10 +33,14 @@ public class SecurityConfig {
 				.anyRequest()
 				.authenticated()
 			)
+			.addFilterBefore(sessionAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+			.formLogin(form -> form.disable())        // 폼 로그인 비활성화
+			.httpBasic(basic -> basic.disable())      // HTTP Basic 비활성화
+			.sessionManagement(session -> session
+				.sessionCreationPolicy(org.springframework.security.config.http.SessionCreationPolicy.IF_REQUIRED)
+			)
 			.csrf(csrf -> csrf.disable())
-			.cors(cors -> {
-			})
-		;
+			.cors(cors -> {});
 
 		return http.build();
 	}

--- a/src/main/java/com/threestar/trainus/global/config/security/SessionAuthenticationFilter.java
+++ b/src/main/java/com/threestar/trainus/global/config/security/SessionAuthenticationFilter.java
@@ -1,0 +1,39 @@
+package com.threestar.trainus.global.security;
+
+import java.io.IOException;
+import java.util.Collections;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+
+@Component
+public class SessionAuthenticationFilter extends OncePerRequestFilter {
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+		FilterChain filterChain) throws ServletException, IOException {
+
+		HttpSession session = request.getSession(false);
+
+		if (session != null) {
+			Long userId = (Long) session.getAttribute("LOGIN_USER");
+
+			if (userId != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+				UsernamePasswordAuthenticationToken authToken =
+					new UsernamePasswordAuthenticationToken(userId, null, Collections.emptyList());
+
+				SecurityContextHolder.getContext().setAuthentication(authToken);
+			}
+		}
+
+		filterChain.doFilter(request, response);
+	}
+}


### PR DESCRIPTION
## 🛠️ 작업 내용
1. 세션 인증 정보 SecurityContext에 주입

<img width="836" height="676" alt="image" src="https://github.com/user-attachments/assets/ebce7560-1eeb-4d3e-ba12-e7b4f2f8f521" />

   
## ✅ PR 유형
- [ ] 새로운 기능 추가
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드 리팩토링
- [ ] 파일 혹은 폴더명 수정

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?

## 🔗 관련 이슈
- #33 

## 💬 기타 참고 사항
