### PR TITLE
feat: 리뷰 작성 간 메타데이터 프로필 업데이트

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
 
+    testImplementation 'com.h2database:h2'
     testCompileOnly 'org.projectlombok:lombok' // 테스트 의존성 추가
     testAnnotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/com/threestar/trainus/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/threestar/trainus/domain/comment/controller/CommentController.java
@@ -17,9 +17,11 @@ import com.threestar.trainus.domain.comment.dto.CommentResponseDto;
 import com.threestar.trainus.domain.comment.service.CommentService;
 import com.threestar.trainus.global.unit.BaseResponse;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 
+@Tag(name = "댓글 API", description = "댓글 작성, 조회, 삭제 관련 API")
 @RestController
 @RequestMapping(("/api/v1/comments/"))
 @RequiredArgsConstructor

--- a/src/main/java/com/threestar/trainus/domain/metadata/entity/ProfileMetadata.java
+++ b/src/main/java/com/threestar/trainus/domain/metadata/entity/ProfileMetadata.java
@@ -16,6 +16,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
 @Entity
@@ -36,6 +37,17 @@ public class ProfileMetadata {
 	@Column(nullable = false)
 	private Integer reviewCount;
 
+	@Setter
 	@Column(nullable = false)
 	private Float rating;
+
+	public void increaseReviewCount() {
+		this.reviewCount++;
+	}
+
+	public Float updateRating(Float newRating) {
+		Float totalRatingBefore = this.rating * (reviewCount - 1);
+		totalRatingBefore += newRating;
+		return totalRatingBefore / reviewCount;
+	}
 }

--- a/src/main/java/com/threestar/trainus/domain/metadata/repository/ProfileMetadataRepository.java
+++ b/src/main/java/com/threestar/trainus/domain/metadata/repository/ProfileMetadataRepository.java
@@ -3,10 +3,20 @@ package com.threestar.trainus.domain.metadata.repository;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.threestar.trainus.domain.metadata.entity.ProfileMetadata;
+
+import jakarta.persistence.LockModeType;
 
 public interface ProfileMetadataRepository extends JpaRepository<ProfileMetadata, Long> {
 
 	Optional<ProfileMetadata> findByUserId(Long userId);
+
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
+	@Query("select p from ProfileMetadata p where p.user.id = :userId")
+	Optional<ProfileMetadata> findWithLockByUserId(@Param("userId") Long userId);
+
 }

--- a/src/main/java/com/threestar/trainus/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/threestar/trainus/domain/review/controller/ReviewController.java
@@ -16,9 +16,11 @@ import com.threestar.trainus.domain.review.dto.ReviewPageResponseDto;
 import com.threestar.trainus.domain.review.service.ReviewService;
 import com.threestar.trainus.global.unit.BaseResponse;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 
+@Tag(name = "리뷰 API", description = "리뷰 작성, 조회 관련 API")
 @RestController
 @RequestMapping("/api/v1/reviews")
 @RequiredArgsConstructor

--- a/src/main/java/com/threestar/trainus/domain/review/service/ReviewService.java
+++ b/src/main/java/com/threestar/trainus/domain/review/service/ReviewService.java
@@ -7,6 +7,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.threestar.trainus.domain.lesson.admin.entity.Lesson;
 import com.threestar.trainus.domain.lesson.admin.repository.LessonRepository;
+import com.threestar.trainus.domain.metadata.entity.ProfileMetadata;
+import com.threestar.trainus.domain.metadata.repository.ProfileMetadataRepository;
 import com.threestar.trainus.domain.review.dto.ReviewCreateRequestDto;
 import com.threestar.trainus.domain.review.dto.ReviewCreateResponseDto;
 import com.threestar.trainus.domain.review.dto.ReviewPageResponseDto;
@@ -28,6 +30,7 @@ public class ReviewService {
 	private final ReviewRepository reviewRepository;
 	private final LessonRepository lessonRepository;
 	private final UserRepository userRepository;
+	private final ProfileMetadataRepository profileMetadataRepository;
 
 	//참여자 테이블에 있는지도 검증 필요 횟수도 한번으로 제한
 
@@ -47,6 +50,8 @@ public class ReviewService {
 		User lessonLeader = userRepository.findById(findLesson.getLessonLeader())
 			.orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
+		//참여자 테이블 검증 추후 추가 -> lessonId 와 userId 다 갖고 있는지
+
 		Review newReview = reviewRepository.save(Review.builder()
 			.reviewer(findUser)
 			.reviewee(lessonLeader)
@@ -56,7 +61,11 @@ public class ReviewService {
 			.image(reviewRequestDto.getReviewImage())
 			.build());
 
-		//MetaData에 데이터 추가 로직 필요
+		ProfileMetadata profileMetadata = profileMetadataRepository.findWithLockByUserId(lessonLeader.getId())  //비관적 락 적용
+			.orElseThrow(() -> new BusinessException(ErrorCode.METADATA_NOT_FOUND));
+
+		profileMetadata.increaseReviewCount();
+		profileMetadata.setRating(profileMetadata.updateRating(reviewRequestDto.getRating()));
 
 		return ReviewMapper.toReviewResponseDto(newReview);
 	}

--- a/src/main/java/com/threestar/trainus/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/threestar/trainus/global/config/security/SecurityConfig.java
@@ -28,7 +28,7 @@ public class SecurityConfig {
 		http
 			.authorizeHttpRequests(auth -> auth
 				.requestMatchers("/api/v1/users/**", "/api/lessons/test-auth", "/swagger-ui/**", "/v3/api-docs/**",
-					"/api/v1/profiles/**", "/api/v1/lessons/**")
+					"/api/v1/profiles/**", "/api/v1/lessons/**", "/api/v1/comments/**", "/api/v1/reviews/**")
 				.permitAll()
 				.anyRequest()
 				.authenticated()

--- a/src/test/java/com/threestar/trainus/domain/comment/controller/CommentControllerTest.java
+++ b/src/test/java/com/threestar/trainus/domain/comment/controller/CommentControllerTest.java
@@ -1,0 +1,201 @@
+package com.threestar.trainus.domain.comment.controller;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.threestar.trainus.domain.comment.dto.CommentCreateRequestDto;
+import com.threestar.trainus.domain.comment.entity.Comment;
+import com.threestar.trainus.domain.comment.repository.CommentRepository;
+import com.threestar.trainus.domain.lesson.admin.entity.Category;
+import com.threestar.trainus.domain.lesson.admin.entity.Lesson;
+import com.threestar.trainus.domain.lesson.admin.repository.LessonRepository;
+import com.threestar.trainus.domain.user.entity.User;
+import com.threestar.trainus.domain.user.entity.UserRole;
+import com.threestar.trainus.domain.user.repository.UserRepository;
+
+@AutoConfigureMockMvc
+@SpringBootTest
+class CommentControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@Autowired
+	private LessonRepository lessonRepository;
+
+	@Autowired
+	private UserRepository userRepository;
+
+	@Autowired
+	private CommentRepository commentRepository;
+
+	private Long lessonId;
+	private Long userId;
+	private Lesson lesson;
+	private User user;
+
+	@BeforeEach
+	void setUp() throws Exception {
+		//더미 User 생성
+		user = userRepository.save(User.builder()
+			.email("dummy@trainus.com")
+			.password("1234")
+			.nickname("테스터")
+			.role(UserRole.USER)
+			.build());
+
+		userId = user.getId();
+
+		lesson = lessonRepository.save(Lesson.builder()
+			.lessonLeader(userId)
+			.lessonName("더미 레슨")
+			.description("설명입니다.")
+			.maxParticipants(10)
+			.startAt(LocalDateTime.now().plusDays(1))
+			.endAt(LocalDateTime.now().plusDays(2))
+			.price(0)
+			.category(Category.BADMINTON)
+			.openTime(null)
+			.openRun(false)
+			.city("서울")
+			.district("강남")
+			.dong("삼성")
+			.addressDetail("코엑스 3층")
+			.build());
+
+		lessonId = lesson.getId();
+	}
+
+	@AfterEach
+	void tearDown() {
+		commentRepository.deleteAll();
+		lessonRepository.deleteAll();
+		userRepository.deleteAll();
+	}
+
+	@Test
+	void create_comment() throws Exception {
+		CommentCreateRequestDto request = new CommentCreateRequestDto();
+		request.setParentCommentId(null);
+		request.setContent("테스트 부모 댓글");
+
+		MockHttpSession session = new MockHttpSession();
+		session.setAttribute("LOGIN_USER", userId);
+
+		mockMvc.perform(post("/api/v1/comments/" + lessonId)
+				.session(session)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isCreated())
+			.andExpect(jsonPath("$.message").value("댓글 등록 완료되었습니다"))
+			.andExpect(jsonPath("$.data.userId").value(userId.intValue()));
+	}
+
+	@Test
+	void readAll_test() throws Exception {
+		User user2 = userRepository.save(User.builder()
+			.email("user2@trainus.com")
+			.password("pw2")
+			.nickname("유저2")
+			.role(UserRole.USER)
+			.build());
+
+		User user3 = userRepository.save(User.builder()
+			.email("user3@trainus.com")
+			.password("pw3")
+			.nickname("유저3")
+			.role(UserRole.USER)
+			.build());
+
+		// 부모 댓글 1 - user
+		Long parentId1 = createComment(null, "댓글1", lessonId, user.getId());
+		createComment(parentId1, "대댓글1", lessonId, user2.getId());
+
+		// 부모 댓글 2 - user2
+		Long parentId2 = createComment(null, "댓글2", lessonId, user2.getId());
+
+		createComment(parentId2, "대댓글2", lessonId, user3.getId());
+		createComment(parentId1, "대댓글2", lessonId, user3.getId());
+
+		// 부모 댓글 3 - user3
+		Long parentId3 = createComment(null, "댓글3", lessonId, user3.getId());
+		createComment(parentId3, "대댓글1", lessonId, user.getId());
+		createComment(parentId2, "대댓글1", lessonId, user.getId());
+		createComment(parentId3, "대댓글2", lessonId, user2.getId());
+
+		mockMvc.perform(get("/api/v1/comments/" + lesson.getId())
+				.param("page", "2")
+				.param("pageSize", "5"))
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.message").value("댓글 조회 성공"));
+		// .andExpect(jsonPath("$.data.commentCount").value(9))
+		// .andExpect(jsonPath("$.data.comments.length()").value(5))
+		// .andExpect(jsonPath("$.data.comments[0].content").value("댓글1"))
+		// .andExpect(jsonPath("$.data.comments[0].userId").value(user.getId().intValue()));
+	}
+
+	private Long createComment(Long parentId, String content, Long lessonId, Long userId) throws Exception {
+		CommentCreateRequestDto request = new CommentCreateRequestDto();
+		request.setParentCommentId(parentId);
+		request.setContent(content);
+
+		MockHttpSession session = new MockHttpSession();
+		session.setAttribute("LOGIN_USER", userId);
+
+		String response = mockMvc.perform(post("/api/v1/comments/" + lessonId)
+				.session(session)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isCreated())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+
+		// JSON 파싱해서 commentId 추출
+		return objectMapper.readTree(response).path("data").path("commentId").asLong();
+	}
+
+	@Test
+	void delete_comment() throws Exception {
+		MockHttpSession session = new MockHttpSession();
+		User writer = userRepository.save(User.builder()
+			.email("writer@trainus.com")
+			.password("1234")
+			.nickname("작성자")
+			.role(UserRole.USER)
+			.build());
+
+		session.setAttribute("LOGIN_USER", writer.getId());
+
+		Long commentId = createComment(null, "댓글1", lessonId, writer.getId());
+
+		mockMvc.perform(delete("/api/v1/comments/" + commentId)
+				.session(session))
+			.andExpect(status().isNoContent());
+
+		Optional<Comment> deleted = commentRepository.findById(commentId);
+		assertThat(deleted).isEmpty();
+
+	}
+
+}

--- a/src/test/java/com/threestar/trainus/domain/review/controller/ReviewControllerTest.java
+++ b/src/test/java/com/threestar/trainus/domain/review/controller/ReviewControllerTest.java
@@ -1,0 +1,190 @@
+package com.threestar.trainus.domain.review.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.threestar.trainus.domain.lesson.admin.entity.Category;
+import com.threestar.trainus.domain.lesson.admin.entity.Lesson;
+import com.threestar.trainus.domain.lesson.admin.repository.LessonRepository;
+import com.threestar.trainus.domain.metadata.entity.ProfileMetadata;
+import com.threestar.trainus.domain.metadata.repository.ProfileMetadataRepository;
+import com.threestar.trainus.domain.review.dto.ReviewCreateRequestDto;
+import com.threestar.trainus.domain.review.entity.Review;
+import com.threestar.trainus.domain.review.repository.ReviewRepository;
+import com.threestar.trainus.domain.user.entity.User;
+import com.threestar.trainus.domain.user.entity.UserRole;
+import com.threestar.trainus.domain.user.repository.UserRepository;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class ReviewControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@Autowired
+	private LessonRepository lessonRepository;
+
+	@Autowired
+	private UserRepository userRepository;
+
+	@Autowired
+	private ReviewRepository reviewRepository;
+
+	@Autowired
+	private ProfileMetadataRepository profileMetadataRepository;
+
+	private Long lessonId;
+	private Lesson lesson;
+	private User reviewer1;
+	private User reviewer2;
+	private User reviewee;
+
+	@BeforeEach
+	void setUp() throws Exception {
+		//더미 User 생성
+		reviewee = userRepository.save(User.builder()
+			.email("dummy@trainus.com")
+			.password("1234")
+			.nickname("강사")
+			.role(UserRole.USER)
+			.build());
+
+		reviewer1 = userRepository.save(User.builder()
+			.email("reviewer1@test.com")
+			.password("pw")
+			.nickname("회원")
+			.role(UserRole.USER)
+			.build());
+
+		reviewer2 = userRepository.save(User.builder()
+			.email("reviewer2@test.com")
+			.password("pw")
+			.nickname("회원2")
+			.role(UserRole.USER)
+			.build());
+
+		lesson = lessonRepository.save(Lesson.builder()
+			.lessonLeader(reviewee.getId())
+			.lessonName("더미 레슨")
+			.description("설명입니다.")
+			.maxParticipants(10)
+			.startAt(LocalDateTime.now().minusDays(1))
+			.endAt(LocalDateTime.now().plusDays(2))
+			.price(0)
+			.category(Category.BADMINTON)
+			.openTime(null)
+			.openRun(false)
+			.city("서울")
+			.district("강남")
+			.dong("삼성")
+			.addressDetail("코엑스 3층")
+			.build());
+
+		lessonId = lesson.getId();
+	}
+
+	@AfterEach
+	void tearDown() {
+		reviewRepository.deleteAll();
+		lessonRepository.deleteAll();
+		userRepository.deleteAll();
+	}
+
+	@Test
+	void createReview() throws Exception {
+
+		profileMetadataRepository.save(ProfileMetadata.builder()
+			.user(reviewee)
+			.reviewCount(0)
+			.rating(0.0f)
+			.build());
+
+		ReviewCreateRequestDto request = new ReviewCreateRequestDto();
+		request.setContent("테스트 리뷰1");
+		request.setRating(3.5f);
+		request.setReviewImage("https://example.com/image.png");
+
+		MockHttpSession session = new MockHttpSession();
+		session.setAttribute("LOGIN_USER", reviewer1.getId());
+
+		mockMvc.perform(post("/api/v1/reviews/" + lessonId)
+				.session(session)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andDo(print())
+			.andExpect(status().isCreated())
+			.andExpect(jsonPath("$.message").value("작성이 완료됐습니다."))
+			.andExpect(jsonPath("$.data.content").value("테스트 리뷰1"));
+
+		ProfileMetadata profileMetadata = profileMetadataRepository.findByUserId(reviewee.getId()).orElseThrow();
+		Assertions.assertEquals(1, profileMetadata.getReviewCount());
+		Assertions.assertEquals(3.5f, profileMetadata.getRating());
+
+		ReviewCreateRequestDto request2 = new ReviewCreateRequestDto();
+		request2.setContent("테스트 리뷰2");
+		request2.setRating(4.5f);
+		request2.setReviewImage("https://example.com/image.png");
+
+		session.setAttribute("LOGIN_USER", reviewer2.getId());
+
+		mockMvc.perform(post("/api/v1/reviews/" + lessonId)
+				.session(session)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request2)))
+			.andDo(print())
+			.andExpect(status().isCreated())
+			.andExpect(jsonPath("$.message").value("작성이 완료됐습니다."))
+			.andExpect(jsonPath("$.data.content").value("테스트 리뷰2"));
+
+		ProfileMetadata profileMetadata2 = profileMetadataRepository.findByUserId(reviewee.getId()).orElseThrow();
+		Assertions.assertEquals(2, profileMetadata2.getReviewCount());
+		Assertions.assertEquals(4.0f, profileMetadata2.getRating());
+	}
+
+	@Test
+	void readAll_test() throws Exception {
+		reviewRepository.save(Review.builder()
+			.reviewer(reviewer1)
+			.reviewee(reviewee)
+			.lesson(lesson)
+			.content("리뷰1")
+			.rating(5.0f)
+			.build());
+
+		reviewRepository.save(Review.builder()
+			.reviewer(reviewer2)
+			.reviewee(reviewee)
+			.lesson(lesson)
+			.content("리뷰1")
+			.rating(4.5f)
+			.build());
+
+		mockMvc.perform(get("/api/v1/reviews/" + reviewee.getId())
+				.param("page", "1")
+				.param("pageSize", "10"))
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.message").value("조회가 완료됐습니다."));
+
+	}
+
+}


### PR DESCRIPTION
## 🛠️ 작업 내용
리뷰 작성 시 메타데이터 테이블에 있는 리뷰 수(비관적 락 적용), 평점 계산 후 업데이트 부분 추가
테스트 코드 및 컨트롤러에 Swagger 관련 설명 추가 
   
## ✅ PR 유형
- [x] 새로운 기능 추가
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드 리팩토링
- [ ] 파일 혹은 폴더명 수정

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?

## 🔗 관련 이슈
- #30 

## 💬 기타 참고 사항
테스트는 현재 h2 memory db 사용해서 진행했습니다.
아직 lessonParticipant 레포지토리가 안보여서 이쪽 검증 로직은 추후 진행하겠습니다.
