### PR TITLE
fix : 레슨생성시 이름수제한변경

### DIFF
--- a/src/main/java/com/threestar/trainus/domain/lesson/admin/dto/LessonCreateRequestDto.java
+++ b/src/main/java/com/threestar/trainus/domain/lesson/admin/dto/LessonCreateRequestDto.java
@@ -16,7 +16,7 @@ import jakarta.validation.constraints.Size;
 public record LessonCreateRequestDto(
 
 	@NotBlank(message = "레슨 이름은 필수입니다.")
-	@Size(max = 20, message = "레슨명은 20자 이내여야 합니다.")
+	@Size(max = 50, message = "레슨명은 5m0자 이내여야 합니다.")
 	String lessonName,
 
 	@NotBlank(message = "레슨 설명은 필수입니다.")

--- a/src/main/java/com/threestar/trainus/domain/lesson/admin/dto/LessonCreateRequestDto.java
+++ b/src/main/java/com/threestar/trainus/domain/lesson/admin/dto/LessonCreateRequestDto.java
@@ -16,7 +16,7 @@ import jakarta.validation.constraints.Size;
 public record LessonCreateRequestDto(
 
 	@NotBlank(message = "레슨 이름은 필수입니다.")
-	@Size(max = 50, message = "레슨명은 5m0자 이내여야 합니다.")
+	@Size(max = 50, message = "레슨명은 50자 이내여야 합니다.")
 	String lessonName,
 
 	@NotBlank(message = "레슨 설명은 필수입니다.")

--- a/src/main/java/com/threestar/trainus/domain/lesson/admin/entity/Lesson.java
+++ b/src/main/java/com/threestar/trainus/domain/lesson/admin/entity/Lesson.java
@@ -30,7 +30,7 @@ public class Lesson extends BaseDateEntity {
 	@Column(nullable = false)
 	private Long lessonLeader;
 
-	@Column(nullable = false, length = 20)
+	@Column(nullable = false, length = 50)
 	private String lessonName;
 
 	@Column(nullable = false, length = 255)


### PR DESCRIPTION
## 🛠️ 작업 내용
 레슨생성시 이름수제한변경, 20->50
   
## ✅ PR 유형
- [x] 새로운 기능 추가
- [x] CSS 등 사용자 UI 디자인 변경
- [x] 코드 리팩토링
- [x] 파일 혹은 폴더명 수정

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?

## 🔗 관련 이슈
- 

## 💬 기타 참고 사항
