### PR TITLE
feat: 랭킹 조회 기능 구현

### DIFF
--- a/src/main/java/com/threestar/trainus/domain/lesson/admin/entity/Lesson.java
+++ b/src/main/java/com/threestar/trainus/domain/lesson/admin/entity/Lesson.java
@@ -30,7 +30,7 @@ public class Lesson extends BaseDateEntity {
 	@Column(nullable = false)
 	private Long lessonLeader;
 
-	@Column(nullable = false, length = 20)
+	@Column(nullable = false, length = 40)
 	private String lessonName;
 
 	@Column(nullable = false, length = 255)

--- a/src/main/java/com/threestar/trainus/domain/metadata/mapper/ProfileMetadataMapper.java
+++ b/src/main/java/com/threestar/trainus/domain/metadata/mapper/ProfileMetadataMapper.java
@@ -4,10 +4,11 @@ import com.threestar.trainus.domain.metadata.dto.ProfileMetadataResponseDto;
 import com.threestar.trainus.domain.metadata.entity.ProfileMetadata;
 import com.threestar.trainus.domain.user.entity.User;
 
-public class ProfileMetadataMapper {
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 
-	private ProfileMetadataMapper() {
-	}
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProfileMetadataMapper {
 
 	public static ProfileMetadataResponseDto toResponseDto(ProfileMetadata profileMetadata, User user) {
 		return new ProfileMetadataResponseDto(

--- a/src/main/java/com/threestar/trainus/domain/profile/controller/ProfileController.java
+++ b/src/main/java/com/threestar/trainus/domain/profile/controller/ProfileController.java
@@ -15,10 +15,12 @@ import com.threestar.trainus.domain.profile.dto.ProfileUpdateRequestDto;
 import com.threestar.trainus.domain.profile.service.ProfileFacadeService;
 import com.threestar.trainus.global.unit.BaseResponse;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
+@Tag(name = "유저 프로필 API", description = "유저 프로필 조회/수정 API")
 @RestController
 @RequestMapping("api/v1/profiles")
 @RequiredArgsConstructor

--- a/src/main/java/com/threestar/trainus/domain/profile/dto/ProfileUpdateRequestDto.java
+++ b/src/main/java/com/threestar/trainus/domain/profile/dto/ProfileUpdateRequestDto.java
@@ -7,7 +7,7 @@ import jakarta.validation.constraints.Size;
 
 public record ProfileUpdateRequestDto(
 
-	@Size(max = 255, message = "프로필 이미지 URL은 255자 이하여야 합니다.")
+	@Size(max = 2048, message = "프로필 이미지 URL은 2048자 이하여야 합니다.")
 	@Pattern(
 		regexp = "^$|^https?://[\\w\\-._~:/?#\\[\\]@!$&'()*+,;=%]+$",
 		message = "올바른 URL 형식이어야 합니다."

--- a/src/main/java/com/threestar/trainus/domain/profile/mapper/ProfileDetailMapper.java
+++ b/src/main/java/com/threestar/trainus/domain/profile/mapper/ProfileDetailMapper.java
@@ -4,11 +4,11 @@ import com.threestar.trainus.domain.metadata.dto.ProfileMetadataResponseDto;
 import com.threestar.trainus.domain.profile.dto.ProfileDetailResponseDto;
 import com.threestar.trainus.domain.profile.dto.ProfileResponseDto;
 
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ProfileDetailMapper {
-
-	private ProfileDetailMapper() {
-	}
 
 	public static ProfileDetailResponseDto toDetailResponseDto(
 		ProfileResponseDto profile,

--- a/src/main/java/com/threestar/trainus/domain/profile/mapper/ProfileMapper.java
+++ b/src/main/java/com/threestar/trainus/domain/profile/mapper/ProfileMapper.java
@@ -4,11 +4,11 @@ import com.threestar.trainus.domain.profile.dto.ProfileResponseDto;
 import com.threestar.trainus.domain.profile.entity.Profile;
 import com.threestar.trainus.domain.user.entity.User;
 
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ProfileMapper {
-
-	private ProfileMapper() {
-
-	}
 
 	public static ProfileResponseDto toResponseDto(Profile profile, User user) {
 		return new ProfileResponseDto(

--- a/src/main/java/com/threestar/trainus/domain/ranking/controller/RankingController.java
+++ b/src/main/java/com/threestar/trainus/domain/ranking/controller/RankingController.java
@@ -1,0 +1,29 @@
+package com.threestar.trainus.domain.ranking.controller;
+
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.threestar.trainus.domain.ranking.dto.RankingResponseDto;
+import com.threestar.trainus.domain.ranking.service.RankingService;
+import com.threestar.trainus.global.unit.BaseResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/rankings")
+@RequiredArgsConstructor
+public class RankingController {
+
+	private final RankingService rankingService;
+
+	@GetMapping
+	public ResponseEntity<BaseResponse<List<RankingResponseDto>>> getRankings() {
+		List<RankingResponseDto> rankings = rankingService.getTopRankings();
+		return BaseResponse.ok("전체 랭킹 조회 성공", rankings, HttpStatus.OK);
+	}
+}

--- a/src/main/java/com/threestar/trainus/domain/ranking/controller/RankingController.java
+++ b/src/main/java/com/threestar/trainus/domain/ranking/controller/RankingController.java
@@ -12,8 +12,10 @@ import com.threestar.trainus.domain.ranking.dto.RankingResponseDto;
 import com.threestar.trainus.domain.ranking.service.RankingService;
 import com.threestar.trainus.global.unit.BaseResponse;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
+@Tag(name = "랭킹 조회 API", description = "랭킹 조회(카테고리 상관없이 전체 1~10등) API")
 @RestController
 @RequestMapping("/api/v1/rankings")
 @RequiredArgsConstructor

--- a/src/main/java/com/threestar/trainus/domain/ranking/dto/RankingData.java
+++ b/src/main/java/com/threestar/trainus/domain/ranking/dto/RankingData.java
@@ -1,0 +1,13 @@
+package com.threestar.trainus.domain.ranking.dto;
+
+public interface RankingData {
+	Long getUserId();
+
+	String getUserNickname();
+
+	Integer getReviewCount();
+
+	Float getRating();
+
+	String getProfileImage();
+}

--- a/src/main/java/com/threestar/trainus/domain/ranking/dto/RankingResponseDto.java
+++ b/src/main/java/com/threestar/trainus/domain/ranking/dto/RankingResponseDto.java
@@ -1,0 +1,19 @@
+package com.threestar.trainus.domain.ranking.dto;
+
+import com.threestar.trainus.domain.lesson.admin.entity.Category;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class RankingResponseDto {
+
+	private Long userId;
+	private String userNickname;
+	private Float rating;
+	private Integer reviewCount;
+	private Category category;
+	private Integer rank;
+	private String profileImage;
+}

--- a/src/main/java/com/threestar/trainus/domain/ranking/repository/RankingRepository.java
+++ b/src/main/java/com/threestar/trainus/domain/ranking/repository/RankingRepository.java
@@ -1,0 +1,31 @@
+package com.threestar.trainus.domain.ranking.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import com.threestar.trainus.domain.metadata.entity.ProfileMetadata;
+import com.threestar.trainus.domain.ranking.dto.RankingData;
+
+public interface RankingRepository extends JpaRepository<ProfileMetadata, Long> {
+
+	@Query("""
+    SELECT pm.user.id as userId,
+           pm.user.nickname as userNickname, 
+           pm.reviewCount as reviewCount,
+           pm.rating as rating,
+           p.profileImage as profileImage
+    FROM ProfileMetadata pm
+    JOIN pm.user u
+    LEFT JOIN Profile p ON p.user = u
+    WHERE pm.reviewCount >= 20
+    ORDER BY (
+        (pm.rating / 5.0) * 0.5 + 
+        (LEAST(pm.reviewCount, 100) / 100.0) * 0.5
+    ) DESC
+    LIMIT 10
+    """)
+	List<RankingData> findTopRankings();
+
+}

--- a/src/main/java/com/threestar/trainus/domain/ranking/service/RankingService.java
+++ b/src/main/java/com/threestar/trainus/domain/ranking/service/RankingService.java
@@ -1,0 +1,91 @@
+package com.threestar.trainus.domain.ranking.service;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.threestar.trainus.domain.ranking.dto.RankingData;
+import com.threestar.trainus.domain.ranking.dto.RankingResponseDto;
+import com.threestar.trainus.domain.ranking.repository.RankingRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RankingService {
+
+	private final RankingRepository rankingRepository;
+	private final RedisTemplate<String, String> redisTemplate;
+	private final ObjectMapper objectMapper;
+
+	private static final String RANKING_KEY = "ranking:all:top10";
+
+	public List<RankingResponseDto> getTopRankings() {
+		try {
+			String cachedData = redisTemplate.opsForValue().get(RANKING_KEY);
+			if (cachedData != null) {
+				return objectMapper.readValue(cachedData, new TypeReference<List<RankingResponseDto>>() {
+				});
+			}
+		} catch (Exception e) {
+			log.warn("레디스 조회 실패: {}", e.getMessage());
+		}
+
+		List<RankingResponseDto> rankings = calculateRankings();
+		saveToRedis(rankings);
+
+		return rankings;
+	}
+
+	private List<RankingResponseDto> calculateRankings() {
+		List<RankingData> data = rankingRepository.findTopRankings();
+
+		List<RankingResponseDto> rankings = new ArrayList<>();
+
+		for (int i = 0; i < data.size(); i++) {
+			RankingData item = data.get(i);
+			rankings.add(RankingResponseDto.builder()
+				.userId(item.getUserId())
+				.userNickname(item.getUserNickname())
+				.category(null) //카테고리별 분류는 추후 도입
+				.rating(item.getRating())
+				.reviewCount(item.getReviewCount())
+				.rank(i + 1)
+				.profileImage(item.getProfileImage())
+				.build());
+		}
+
+		return rankings;
+	}
+
+	private void saveToRedis(List<RankingResponseDto> rankings) {
+		try {
+			String json = objectMapper.writeValueAsString(rankings);
+			redisTemplate.opsForValue().set(RANKING_KEY, json, Duration.ofHours(24));
+			log.info("Redis에 랭킹 데이터 저장 완료");
+		} catch (Exception e) {
+			log.warn("Redis 저장 실패: {}", e.getMessage());
+		}
+	}
+
+	//매 자정마다 랭킹 업데이트
+	@Scheduled(cron = "0 0 0 * * *")
+	public void updateRankings() {
+		log.info("랭킹 업데이트 시작");
+		try {
+			List<RankingResponseDto> rankings = calculateRankings();
+			saveToRedis(rankings);
+			log.info("랭킹 업데이트 완료");
+		} catch (Exception e) {
+			log.error("랭킹 업데이트 실패: {}", e.getMessage(), e);
+		}
+	}
+}

--- a/src/main/java/com/threestar/trainus/domain/user/controller/UserController.java
+++ b/src/main/java/com/threestar/trainus/domain/user/controller/UserController.java
@@ -86,21 +86,4 @@ public class UserController {
 		emailVerificationService.verifyCode(request.email(), request.verificationCode());
 		return BaseResponse.ok("이메일 인증이 완료되었습니다.", null, HttpStatus.OK);
 	}
-
-	//SecurityContext에 잘 올라간 지 테스트
-	@GetMapping("/test-context")
-	public String testSecurityContext(@AuthenticationPrincipal Long userId, HttpSession session) {
-		Long sessionUserId = (Long)session.getAttribute("LOGIN_USER");
-
-		Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-		Long contextUserId = null;
-		if (auth != null && auth.isAuthenticated() && !auth.getPrincipal().equals("anonymousUser")) {
-			contextUserId = (Long)auth.getPrincipal();
-		}
-
-		Long principalUserId = userId;
-
-		return String.format("Session: %s, Context: %s, AuthPrincipal: %s",
-			sessionUserId, contextUserId, principalUserId);
-	}
 }

--- a/src/main/java/com/threestar/trainus/domain/user/controller/UserController.java
+++ b/src/main/java/com/threestar/trainus/domain/user/controller/UserController.java
@@ -1,21 +1,15 @@
 package com.threestar.trainus.domain.user.controller;
 
-import java.security.Principal;
-
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.threestar.trainus.domain.user.dto.EmailVerificationDto;
 import com.threestar.trainus.domain.user.dto.EmailSendRequestDto;
 import com.threestar.trainus.domain.user.dto.EmailSendResponseDto;
+import com.threestar.trainus.domain.user.dto.EmailVerificationDto;
 import com.threestar.trainus.domain.user.dto.LoginRequestDto;
 import com.threestar.trainus.domain.user.dto.LoginResponseDto;
 import com.threestar.trainus.domain.user.dto.NicknameCheckRequestDto;

--- a/src/main/java/com/threestar/trainus/domain/user/dto/EmailSendRequestDto.java
+++ b/src/main/java/com/threestar/trainus/domain/user/dto/EmailSendRequestDto.java
@@ -8,7 +8,7 @@ public record EmailSendRequestDto(
 
 	@NotBlank(message = "이메일은 필수입니다.")
 	@Email(message = "올바른 이메일 형식이 아닙니다.")
-	@Size(max = 30, message = "이메일은 최대 30자 입니다.")
+	@Size(max = 100, message = "이메일은 최대 100자 입니다.")
 	String email
 ) {
 }

--- a/src/main/java/com/threestar/trainus/domain/user/dto/SignupRequestDto.java
+++ b/src/main/java/com/threestar/trainus/domain/user/dto/SignupRequestDto.java
@@ -8,7 +8,7 @@ public record SignupRequestDto(
 
 	@NotBlank(message = "이메일은 필수입니다.")
 	@Email(message = "올바른 이메일 형식이 아닙니다.")
-	@Size(max = 30, message = "이메일은 최대 30자 입니다.")
+	@Size(max = 100, message = "이메일은 최대 100자 입니다.")
 	String email,
 
 	@NotBlank(message = "비밀번호는 필수입니다.")

--- a/src/main/java/com/threestar/trainus/domain/user/entity/User.java
+++ b/src/main/java/com/threestar/trainus/domain/user/entity/User.java
@@ -39,7 +39,7 @@ public class User extends BaseDateEntity {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	@Column(length = 30, nullable = false, unique = true)
+	@Column(length = 100, nullable = false, unique = true)
 	private String email;
 
 	@Column(length = 100, nullable = false)

--- a/src/main/java/com/threestar/trainus/domain/user/mapper/UserMapper.java
+++ b/src/main/java/com/threestar/trainus/domain/user/mapper/UserMapper.java
@@ -6,10 +6,11 @@ import com.threestar.trainus.domain.user.dto.SignupResponseDto;
 import com.threestar.trainus.domain.user.entity.User;
 import com.threestar.trainus.domain.user.entity.UserRole;
 
-public class UserMapper {
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 
-	private UserMapper() {
-	}
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserMapper {
 
 	public static User toEntity(SignupRequestDto request, String encodedPassword) {
 		return User.builder()

--- a/src/main/java/com/threestar/trainus/domain/user/service/UserService.java
+++ b/src/main/java/com/threestar/trainus/domain/user/service/UserService.java
@@ -41,7 +41,9 @@ public class UserService {
 			throw new BusinessException(ErrorCode.EMAIL_ALREADY_EXISTS);
 		}
 
-		checkNickname(request.nickname());
+		if (userRepository.existsByNickname(request.nickname())) {
+			throw new BusinessException(ErrorCode.NICKNAME_ALREADY_EXISTS);
+		}
 
 		String encodedPassword = passwordEncoder.encode(request.password());
 
@@ -74,13 +76,5 @@ public class UserService {
 	public void logout(HttpSession session) {
 		session.invalidate();
 		SecurityContextHolder.clearContext();
-	}
-
-	@Transactional(readOnly = true)
-	public void checkNickname(String nickname) {
-
-		if (userRepository.existsByNickname(nickname)) {
-			throw new BusinessException(ErrorCode.NICKNAME_ALREADY_EXISTS);
-		}
 	}
 }

--- a/src/main/java/com/threestar/trainus/domain/user/service/UserService.java
+++ b/src/main/java/com/threestar/trainus/domain/user/service/UserService.java
@@ -77,4 +77,11 @@ public class UserService {
 		session.invalidate();
 		SecurityContextHolder.clearContext();
 	}
+
+	@Transactional(readOnly = true)
+	public void checkNickname(String nickname) {
+		if (userRepository.existsByNickname(nickname)) {
+			throw new BusinessException(ErrorCode.NICKNAME_ALREADY_EXISTS);
+		}
+	}
 }

--- a/src/main/java/com/threestar/trainus/global/config/MockDataInitializer.java
+++ b/src/main/java/com/threestar/trainus/global/config/MockDataInitializer.java
@@ -1,0 +1,232 @@
+package com.threestar.trainus.global.config;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.threestar.trainus.domain.lesson.admin.entity.Category;
+import com.threestar.trainus.domain.lesson.admin.entity.Lesson;
+import com.threestar.trainus.domain.lesson.admin.repository.LessonRepository;
+import com.threestar.trainus.domain.metadata.entity.ProfileMetadata;
+import com.threestar.trainus.domain.metadata.mapper.ProfileMetadataMapper;
+import com.threestar.trainus.domain.metadata.repository.ProfileMetadataRepository;
+import com.threestar.trainus.domain.profile.entity.Profile;
+import com.threestar.trainus.domain.profile.mapper.ProfileMapper;
+import com.threestar.trainus.domain.profile.repository.ProfileRepository;
+import com.threestar.trainus.domain.review.entity.Review;
+import com.threestar.trainus.domain.review.repository.ReviewRepository;
+import com.threestar.trainus.domain.user.entity.User;
+import com.threestar.trainus.domain.user.entity.UserRole;
+import com.threestar.trainus.domain.user.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@org.springframework.context.annotation.Profile("dev") // dev 프로필에서만 실행
+@RequiredArgsConstructor
+public class MockDataInitializer implements CommandLineRunner {
+
+	private final UserRepository userRepository;
+	private final ProfileRepository profileRepository;
+	private final ProfileMetadataRepository profileMetadataRepository;
+	private final LessonRepository lessonRepository;
+	private final ReviewRepository reviewRepository;
+	private final PasswordEncoder passwordEncoder;
+
+	private final Random random = new Random();
+
+	@Override
+	@Transactional
+	public void run(String... args) throws Exception {
+		if (userRepository.count() > 0) {
+			log.info("데이터가 이미 존재합니다. Mock 데이터 생성을 건너뜁니다.");
+			return;
+		}
+
+		log.info("Mock 데이터 생성 시작...");
+
+		// 1. 강사 유저 생성 (15명)
+		List<User> instructors = createInstructors();
+
+		// 2. 수강생 유저 생성 (50명)
+		List<User> students = createStudents();
+
+		// 3. 각 강사별로 레슨 생성
+		List<Lesson> lessons = createLessons(instructors);
+
+		// 4. 리뷰 생성 (ProfileMetadata 업데이트)
+		createReviews(instructors, students, lessons);
+
+		log.info("Mock 데이터 생성 완료!");
+		log.info("생성된 데이터: 강사 {}명, 수강생 {}명, 레슨 {}개",
+			instructors.size(), students.size(), lessons.size());
+	}
+
+	private List<User> createInstructors() {
+		List<User> instructors = new ArrayList<>();
+		String[] instructorNames = {
+			"헬스왕김철수", "요가마스터", "필라테스여신", "러닝코치박", "수영선수이",
+			"테니스프로", "복싱챔피언", "클라이밍킹", "골프레슨프로", "댄스퀸",
+			"크로스핏코치", "배드민턴고수", "탁구선수", "농구코치", "축구감독"
+		};
+
+		for (int i = 0; i < instructorNames.length; i++) {
+			User instructor = User.builder()
+				.email("instructor" + (i + 1) + "@test.com")
+				.password(passwordEncoder.encode("password123"))
+				.nickname(instructorNames[i])
+				.role(UserRole.USER)
+				.build();
+
+			User savedInstructor = userRepository.save(instructor);
+
+			// Profile 생성
+			Profile profile = ProfileMapper.toDefaultEntity(savedInstructor);
+			profile.updateProfile(
+				"https://example.com/instructor" + (i + 1) + ".jpg",
+				instructorNames[i] + "입니다. 최고의 레슨을 제공합니다!"
+			);
+			profileRepository.save(profile);
+
+			// ProfileMetadata 생성 (랭킹용 데이터)
+			ProfileMetadata metadata = ProfileMetadata.builder()
+				.user(savedInstructor)
+				.reviewCount(generateReviewCount())
+				.rating(generateRating())
+				.build();
+			profileMetadataRepository.save(metadata);
+
+			instructors.add(savedInstructor);
+		}
+
+		return instructors;
+	}
+
+	private List<User> createStudents() {
+		List<User> students = new ArrayList<>();
+
+		for (int i = 0; i < 50; i++) {
+			User student = User.builder()
+				.email("student" + (i + 1) + "@test.com")
+				.password(passwordEncoder.encode("password123"))
+				.nickname("수강생" + (i + 1))
+				.role(UserRole.USER)
+				.build();
+
+			User savedStudent = userRepository.save(student);
+
+			// Profile 생성
+			Profile profile = ProfileMapper.toDefaultEntity(savedStudent);
+			profile.updateProfile(
+				"https://example.com/student" + (i + 1) + ".jpg",
+				"운동을 열심히 하는 수강생입니다!"
+			);
+			profileRepository.save(profile);
+
+			// 수강생은 메타데이터 기본값
+			ProfileMetadata metadata = ProfileMetadataMapper.toDefaultEntity(savedStudent);
+			profileMetadataRepository.save(metadata);
+
+			students.add(savedStudent);
+		}
+
+		return students;
+	}
+
+	private List<Lesson> createLessons(List<User> instructors) {
+		List<Lesson> lessons = new ArrayList<>();
+		Category[] categories = Category.values();
+
+		for (User instructor : instructors) {
+			// 각 강사당 2-4개의 레슨 생성
+			int lessonCount = random.nextInt(3) + 2;
+
+			for (int i = 0; i < lessonCount; i++) {
+				Category category = categories[random.nextInt(categories.length)];
+
+				Lesson lesson = Lesson.builder()
+					.lessonLeader(instructor.getId())
+					.lessonName(category.name() + " 레슨" + (i + 1))
+					.description("최고의 " + category.name() + " 레슨입니다!")
+					.maxParticipants(random.nextInt(10) + 5) // 5-14명
+					.startAt(LocalDateTime.now().plusDays(random.nextInt(30) + 1))
+					.endAt(LocalDateTime.now().plusDays(random.nextInt(30) + 1).plusHours(2))
+					.price(random.nextInt(50000) + 10000) // 10,000-60,000원
+					.category(category)
+					.openTime(null)
+					.openRun(false)
+					.city("서울시")
+					.district("강남구")
+					.dong("역삼동")
+					.addressDetail("테스트 주소 " + random.nextInt(100))
+					.build();
+
+				lessons.add(lessonRepository.save(lesson));
+			}
+		}
+
+		return lessons;
+	}
+
+	private void createReviews(List<User> instructors, List<User> students, List<Lesson> lessons) {
+		for (User instructor : instructors) {
+			ProfileMetadata metadata = profileMetadataRepository.findByUserId(instructor.getId())
+				.orElseThrow();
+
+			// 해당 강사의 레슨들 찾기
+			List<Lesson> instructorLessons = lessons.stream()
+				.filter(lesson -> lesson.getLessonLeader().equals(instructor.getId()))
+				.toList();
+
+			if (instructorLessons.isEmpty()) continue;
+
+			// reviewCount만큼 실제 리뷰 생성
+			int reviewCount = metadata.getReviewCount();
+
+			for (int i = 0; i < reviewCount; i++) {
+				User randomStudent = students.get(random.nextInt(students.size()));
+				Lesson randomLesson = instructorLessons.get(random.nextInt(instructorLessons.size()));
+
+				// 평점은 metadata의 rating 주변으로 생성
+				float baseRating = metadata.getRating();
+				float reviewRating = Math.max(1.0f, Math.min(5.0f,
+					baseRating + (random.nextFloat() - 0.5f) * 2)); // ±1점 범위
+
+				Review review = Review.builder()
+					.reviewer(randomStudent)
+					.reviewee(instructor)
+					.lesson(randomLesson)
+					.rating(reviewRating)
+					.content("좋은 레슨이었습니다! 추천해요.")
+					.image(random.nextBoolean() ? "https://example.com/review" + i + ".jpg" : null)
+					.build();
+
+				reviewRepository.save(review);
+			}
+		}
+	}
+
+	private int generateReviewCount() {
+		// 랭킹에 들어갈 강사들(20개 이상)과 그렇지 않은 강사들 섞어서 생성
+		int rand = random.nextInt(100);
+		if (rand < 60) { // 60% 확률로 랭킹 대상
+			return random.nextInt(50) + 20; // 20-69개
+		} else { // 40% 확률로 랭킹 비대상
+			return random.nextInt(20); // 0-19개
+		}
+	}
+
+	private float generateRating() {
+		// 3.0 ~ 5.0 사이의 평점 생성 (소수점 1자리)
+		float rating = 3.0f + random.nextFloat() * 2.0f;
+		return Math.round(rating * 10) / 10.0f;
+	}
+}

--- a/src/main/java/com/threestar/trainus/global/config/MockDataInitializer.java
+++ b/src/main/java/com/threestar/trainus/global/config/MockDataInitializer.java
@@ -186,7 +186,9 @@ public class MockDataInitializer implements CommandLineRunner {
 				.filter(lesson -> lesson.getLessonLeader().equals(instructor.getId()))
 				.toList();
 
-			if (instructorLessons.isEmpty()) continue;
+			if (instructorLessons.isEmpty()) {
+				continue;
+			}
 
 			// reviewCount만큼 실제 리뷰 생성
 			int reviewCount = metadata.getReviewCount();

--- a/src/main/java/com/threestar/trainus/global/config/SchedulerConfig.java
+++ b/src/main/java/com/threestar/trainus/global/config/SchedulerConfig.java
@@ -1,4 +1,9 @@
 package com.threestar.trainus.global.config;
 
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
 public class SchedulerConfig {
 }

--- a/src/main/java/com/threestar/trainus/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/threestar/trainus/global/config/security/SecurityConfig.java
@@ -28,7 +28,8 @@ public class SecurityConfig {
 		http
 			.authorizeHttpRequests(auth -> auth
 				.requestMatchers("/api/v1/users/**", "/api/lessons/test-auth", "/swagger-ui/**", "/v3/api-docs/**",
-					"/api/v1/profiles/**", "/api/v1/lessons/**", "/api/v1/comments/**", "/api/v1/reviews/**")
+					"/api/v1/profiles/**", "/api/v1/lessons/**", "/api/v1/comments/**", "/api/v1/reviews/**"
+					, "/api/v1/rankings/**")
 				.permitAll()
 				.anyRequest()
 				.authenticated()


### PR DESCRIPTION
## 🛠️ 작업 내용
1. 리뷰수 + 평점을 바탕으로 랭킹을 계산하여 1~10등까지의 랭킹을 조회 가능한 기능. (점수 가중치는 50:50이고 리뷰수 20개 이상 유저부터 랭킹 집계) 
2. 매일 자정마다 스케줄링을 통해 랭킹 최신화를 하도록 설정.
3. 1~10등의 유저들은 Redis에 캐싱되어 많은 조회가 들어와도 성능에 문제가 최대한 없게 구현.
<img width="858" height="618" alt="image" src="https://github.com/user-attachments/assets/1f6598ef-93d4-477f-baca-eb7f646590f9" />

   
<img width="651" height="873" alt="image" src="https://github.com/user-attachments/assets/3166e7e0-c01e-4bf0-9fc9-ebcd787e78b1" />

5. Mock데이터를 넣어서 테스트 해보았습니다. 테스트 해보실 분들은
yml파일에

<img width="207" height="91" alt="image" src="https://github.com/user-attachments/assets/b906f8ea-914d-4905-8601-2320f5d2331c" />

사진과 같이 추가 하시고 돌려보시면 될 것 같습니다.

---
## 개선 여지
1. 랭킹 조회하는 쿼리를 손 볼 부분이 많다고 생각.
2. 점수 계산하는 것은 따로 서비스로 빼면 좋을 것 같음.
3. 다음주 성능개선에서 제대로 다뤄볼 얘정.
4. 일반 dto보다 가볍다고 해서 프로젝션 RankingData를 사용했는데 직렬화 문제로 단점이 있다고한 블로그를 발견하여서 좀 더 찾아보겠습니다.
5. 일단 반반으로 가중치를 넣었는데 평점에 가중치를 더 줘야될 것 같네요. 리뷰수 많다고해도 안 좋은 리뷰일 수도 있으니!
---
## TMI
profileImage 응답이 null 값이 나와서 빠뜨린 거 고쳐주고 계속 api 테스트 해봤지만(진짜 엄청 많이) 계속 안 고쳐져서 포기했는데 , 생각해보니 Redis 캐싱 조회라서.. 캐시 삭제 안 해주고 테스트한 거라;;; 뻘짓한 거 였습니다 ㅋ ㅋ ㅋ ;;

## ✅ PR 유형
- [x] 새로운 기능 추가
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드 리팩토링
- [ ] 파일 혹은 폴더명 수정

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?

## 🔗 관련 이슈
- #32 

## 💬 기타 참고 사항
