### PR TITLE
feat : 카테고리별 랭킹 조회 구현

### DIFF
--- a/src/main/java/com/threestar/trainus/domain/profile/controller/ProfileController.java
+++ b/src/main/java/com/threestar/trainus/domain/profile/controller/ProfileController.java
@@ -15,6 +15,7 @@ import com.threestar.trainus.domain.profile.dto.ProfileUpdateRequestDto;
 import com.threestar.trainus.domain.profile.service.ProfileFacadeService;
 import com.threestar.trainus.global.unit.BaseResponse;
 
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
@@ -29,6 +30,7 @@ public class ProfileController {
 	private final ProfileFacadeService facadeService;
 
 	@GetMapping("{userId}")
+	@Operation(summary = "유저 프로필 상세 조회 api")
 	public ResponseEntity<BaseResponse<ProfileDetailResponseDto>> getProfileDetail(
 		@PathVariable Long userId
 	) {
@@ -37,6 +39,7 @@ public class ProfileController {
 	}
 
 	@PatchMapping
+	@Operation(summary = "유저 프로필 수정 api")
 	public ResponseEntity<BaseResponse<ProfileResponseDto>> updateProfile(
 		@Valid @RequestBody ProfileUpdateRequestDto requestDto,
 		HttpSession session

--- a/src/main/java/com/threestar/trainus/domain/ranking/controller/RankingController.java
+++ b/src/main/java/com/threestar/trainus/domain/ranking/controller/RankingController.java
@@ -12,6 +12,7 @@ import com.threestar.trainus.domain.ranking.dto.RankingResponseDto;
 import com.threestar.trainus.domain.ranking.service.RankingService;
 import com.threestar.trainus.global.unit.BaseResponse;
 
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
@@ -24,6 +25,7 @@ public class RankingController {
 	private final RankingService rankingService;
 
 	@GetMapping
+	@Operation(summary = "전체 랭킹 조회 api", description = "카테고리와 관계없이 전체 랭킹 Top10을 조회")
 	public ResponseEntity<BaseResponse<List<RankingResponseDto>>> getRankings() {
 		List<RankingResponseDto> rankings = rankingService.getTopRankings();
 		return BaseResponse.ok("전체 랭킹 조회 성공", rankings, HttpStatus.OK);

--- a/src/main/java/com/threestar/trainus/domain/ranking/controller/RankingController.java
+++ b/src/main/java/com/threestar/trainus/domain/ranking/controller/RankingController.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -27,7 +28,17 @@ public class RankingController {
 	@GetMapping
 	@Operation(summary = "전체 랭킹 조회 api", description = "카테고리와 관계없이 전체 랭킹 Top10을 조회")
 	public ResponseEntity<BaseResponse<List<RankingResponseDto>>> getRankings() {
-		List<RankingResponseDto> rankings = rankingService.getTopRankings();
+		List<RankingResponseDto> rankings = rankingService.getTopRankings("ALL");
 		return BaseResponse.ok("전체 랭킹 조회 성공", rankings, HttpStatus.OK);
 	}
+
+	@GetMapping("/{category}")
+	@Operation(summary = "특정 카테고리 랭킹 조회 api", description = "지정된 카테고리의 랭킹을 조회")
+	public ResponseEntity<BaseResponse<List<RankingResponseDto>>> getRankingsByCategory(
+		@PathVariable String category
+	) {
+		List<RankingResponseDto> rankings = rankingService.getTopRankings(category);
+		return BaseResponse.ok(category + "카테고리별 랭킹 조회 성공", rankings, HttpStatus.OK);
+	}
+
 }

--- a/src/main/java/com/threestar/trainus/domain/ranking/repository/RankingRepository.java
+++ b/src/main/java/com/threestar/trainus/domain/ranking/repository/RankingRepository.java
@@ -5,27 +5,52 @@ import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import com.threestar.trainus.domain.lesson.admin.entity.Category;
 import com.threestar.trainus.domain.metadata.entity.ProfileMetadata;
 import com.threestar.trainus.domain.ranking.dto.RankingData;
+
+import io.lettuce.core.dynamic.annotation.Param;
 
 public interface RankingRepository extends JpaRepository<ProfileMetadata, Long> {
 
 	@Query("""
-    SELECT pm.user.id as userId,
-           pm.user.nickname as userNickname, 
-           pm.reviewCount as reviewCount,
-           pm.rating as rating,
-           p.profileImage as profileImage
-    FROM ProfileMetadata pm
-    JOIN pm.user u
-    LEFT JOIN Profile p ON p.user = u
-    WHERE pm.reviewCount >= 20
-    ORDER BY (
-        (pm.rating / 5.0) * 0.5 + 
-        (LEAST(pm.reviewCount, 100) / 100.0) * 0.5
-    ) DESC
-    LIMIT 10
-    """)
+		SELECT pm.user.id as userId,
+		       pm.user.nickname as userNickname, 
+		       pm.reviewCount as reviewCount,
+		       pm.rating as rating,
+		       p.profileImage as profileImage
+		FROM ProfileMetadata pm
+		JOIN pm.user u
+		LEFT JOIN Profile p ON p.user = u
+		WHERE pm.reviewCount >= 10
+		ORDER BY (
+		    (pm.rating / 5.0) * 0.5 + 
+		    (LEAST(pm.reviewCount, 100) / 100.0) * 0.5
+		) DESC
+		LIMIT 10
+		""")
 	List<RankingData> findTopRankings();
+
+	@Query("""
+		SELECT r.reviewee.id as userId,
+		           r.reviewee.nickname as userNickname,
+		           CAST(COUNT(r.reviewId) AS INTEGER) as reviewCount,
+		           CAST(AVG(r.rating) AS FLOAT) as rating,
+		           p.profileImage as profileImage
+		    FROM Review r
+		    JOIN r.lesson l
+		    JOIN r.reviewee u
+		    LEFT JOIN Profile p ON p.user = u
+		    WHERE l.category = :category
+		    AND r.deletedAt IS NULL
+		    GROUP BY r.reviewee.id, r.reviewee.nickname, p.profileImage
+		    HAVING COUNT(r.reviewId) >= 10
+		    ORDER BY (
+		        (AVG(r.rating) / 5.0) * 0.5 +
+		        (LEAST(COUNT(r.reviewId), 100) / 100.0) * 0.5
+		    ) DESC
+		    LIMIT 10
+		""")
+	List<RankingData> findTopRankingsByCategory(@Param("category") Category category);
 
 }

--- a/src/main/java/com/threestar/trainus/domain/ranking/repository/RankingRepository.java
+++ b/src/main/java/com/threestar/trainus/domain/ranking/repository/RankingRepository.java
@@ -4,28 +4,27 @@ import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.threestar.trainus.domain.lesson.admin.entity.Category;
 import com.threestar.trainus.domain.metadata.entity.ProfileMetadata;
 import com.threestar.trainus.domain.ranking.dto.RankingData;
 
-import io.lettuce.core.dynamic.annotation.Param;
-
 public interface RankingRepository extends JpaRepository<ProfileMetadata, Long> {
 
 	@Query("""
 		SELECT pm.user.id as userId,
-		       pm.user.nickname as userNickname, 
-		       pm.reviewCount as reviewCount,
-		       pm.rating as rating,
-		       p.profileImage as profileImage
+			pm.user.nickname as userNickname,
+			pm.reviewCount as reviewCount,
+			pm.rating as rating,
+			p.profileImage as profileImage
 		FROM ProfileMetadata pm
 		JOIN pm.user u
 		LEFT JOIN Profile p ON p.user = u
-		WHERE pm.reviewCount >= 10
+		WHERE pm.reviewCount >= 20
 		ORDER BY (
-		    (pm.rating / 5.0) * 0.5 + 
-		    (LEAST(pm.reviewCount, 100) / 100.0) * 0.5
+			(pm.rating / 5.0) * 0.5 +
+			(LEAST(pm.reviewCount, 100) / 100.0) * 0.5
 		) DESC
 		LIMIT 10
 		""")
@@ -33,24 +32,23 @@ public interface RankingRepository extends JpaRepository<ProfileMetadata, Long> 
 
 	@Query("""
 		SELECT r.reviewee.id as userId,
-		           r.reviewee.nickname as userNickname,
-		           CAST(COUNT(r.reviewId) AS INTEGER) as reviewCount,
-		           CAST(AVG(r.rating) AS FLOAT) as rating,
-		           p.profileImage as profileImage
-		    FROM Review r
-		    JOIN r.lesson l
-		    JOIN r.reviewee u
-		    LEFT JOIN Profile p ON p.user = u
-		    WHERE l.category = :category
-		    AND r.deletedAt IS NULL
-		    GROUP BY r.reviewee.id, r.reviewee.nickname, p.profileImage
-		    HAVING COUNT(r.reviewId) >= 10
-		    ORDER BY (
-		        (AVG(r.rating) / 5.0) * 0.5 +
-		        (LEAST(COUNT(r.reviewId), 100) / 100.0) * 0.5
-		    ) DESC
-		    LIMIT 10
+			r.reviewee.nickname as userNickname,
+			CAST(COUNT(r.reviewId) AS INTEGER) as reviewCount,
+			AST(AVG(r.rating) AS FLOAT) as rating,
+			p.profileImage as profileImage
+		FROM Review r
+		JOIN r.lesson l
+		JOIN r.reviewee u
+		LEFT JOIN Profile p ON p.user = u
+		WHERE l.category = :category
+		AND r.deletedAt IS NULL
+		GROUP BY r.reviewee.id, r.reviewee.nickname, p.profileImage
+		HAVING COUNT(r.reviewId) >= 20
+		ORDER BY (
+			(AVG(r.rating) / 5.0) * 0.5 +
+			(LEAST(COUNT(r.reviewId), 100) / 100.0) * 0.5
+		) DESC
+		LIMIT 10
 		""")
 	List<RankingData> findTopRankingsByCategory(@Param("category") Category category);
-
 }

--- a/src/main/java/com/threestar/trainus/domain/ranking/service/RankingService.java
+++ b/src/main/java/com/threestar/trainus/domain/ranking/service/RankingService.java
@@ -2,7 +2,9 @@ package com.threestar.trainus.domain.ranking.service;
 
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -10,9 +12,12 @@ import org.springframework.stereotype.Service;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.threestar.trainus.domain.lesson.admin.entity.Category;
 import com.threestar.trainus.domain.ranking.dto.RankingData;
 import com.threestar.trainus.domain.ranking.dto.RankingResponseDto;
 import com.threestar.trainus.domain.ranking.repository.RankingRepository;
+import com.threestar.trainus.global.exception.domain.ErrorCode;
+import com.threestar.trainus.global.exception.handler.BusinessException;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -27,10 +32,25 @@ public class RankingService {
 	private final ObjectMapper objectMapper;
 
 	private static final String RANKING_KEY = "ranking:all:top10";
+	private static final String CATEGORY_RANKING_KEY_PREFIX = "ranking:";
+	private static final String CATEGORY_RANKING_KEY_SUFFIX = ":top10";
 
-	public List<RankingResponseDto> getTopRankings() {
+	public List<RankingResponseDto> getTopRankings(String categoryStr) {
+
+		Category category = null;
+		String cacheKey = RANKING_KEY;
+
+		if (!"ALL".equalsIgnoreCase(categoryStr)) {
+			try {
+				category = Category.valueOf(categoryStr.toUpperCase());
+				cacheKey = CATEGORY_RANKING_KEY_PREFIX + categoryStr.toLowerCase() + CATEGORY_RANKING_KEY_SUFFIX;
+			} catch (IllegalArgumentException e) {
+				throw new BusinessException(ErrorCode.INVALID_CATEGORY);
+			}
+		}
+
 		try {
-			String cachedData = redisTemplate.opsForValue().get(RANKING_KEY);
+			String cachedData = redisTemplate.opsForValue().get(cacheKey);
 			if (cachedData != null) {
 				return objectMapper.readValue(cachedData, new TypeReference<List<RankingResponseDto>>() {
 				});
@@ -39,14 +59,15 @@ public class RankingService {
 			log.warn("레디스 조회 실패: {}", e.getMessage());
 		}
 
-		List<RankingResponseDto> rankings = calculateRankings();
-		saveToRedis(rankings);
+		List<RankingResponseDto> rankings = calculateRankings(category);
+		saveToRedis(rankings, cacheKey);
 
 		return rankings;
 	}
 
-	private List<RankingResponseDto> calculateRankings() {
-		List<RankingData> data = rankingRepository.findTopRankings();
+	private List<RankingResponseDto> calculateRankings(Category category) {
+		List<RankingData> data = (category == null) ? rankingRepository.findTopRankings() :
+			rankingRepository.findTopRankingsByCategory(category);
 
 		List<RankingResponseDto> rankings = new ArrayList<>();
 
@@ -55,7 +76,7 @@ public class RankingService {
 			rankings.add(RankingResponseDto.builder()
 				.userId(item.getUserId())
 				.userNickname(item.getUserNickname())
-				.category(null) //카테고리별 분류는 추후 도입
+				.category(category) //null이면 전체 조회
 				.rating(item.getRating())
 				.reviewCount(item.getReviewCount())
 				.rank(i + 1)
@@ -66,11 +87,10 @@ public class RankingService {
 		return rankings;
 	}
 
-	private void saveToRedis(List<RankingResponseDto> rankings) {
+	private void saveToRedis(List<RankingResponseDto> rankings, String cacheKey) {
 		try {
 			String json = objectMapper.writeValueAsString(rankings);
-			redisTemplate.opsForValue().set(RANKING_KEY, json, Duration.ofHours(24));
-			log.info("Redis에 랭킹 데이터 저장 완료");
+			redisTemplate.opsForValue().set(cacheKey, json, Duration.ofHours(24));
 		} catch (Exception e) {
 			log.warn("Redis 저장 실패: {}", e.getMessage());
 		}
@@ -80,10 +100,22 @@ public class RankingService {
 	@Scheduled(cron = "0 0 0 * * *")
 	public void updateRankings() {
 		log.info("랭킹 업데이트 시작");
+
+		Map<String, Integer> categoryCounts = new HashMap<>();
+
 		try {
-			List<RankingResponseDto> rankings = calculateRankings();
-			saveToRedis(rankings);
-			log.info("랭킹 업데이트 완료");
+			//전체 랭킹 업데이트
+			List<RankingResponseDto> allRankings = calculateRankings(null);
+			saveToRedis(allRankings, RANKING_KEY);
+			categoryCounts.put("ALL", allRankings.size());
+
+			//카테고리별 랭킹 업데이트
+			for (Category category : Category.values()) {
+				List<RankingResponseDto> categoryRankings = calculateRankings(category);
+				String cacheKey = CATEGORY_RANKING_KEY_PREFIX + category.name().toLowerCase() + CATEGORY_RANKING_KEY_SUFFIX;
+				saveToRedis(categoryRankings, cacheKey);
+				categoryCounts.put(category.name(), categoryRankings.size());
+			}
 		} catch (Exception e) {
 			log.error("랭킹 업데이트 실패: {}", e.getMessage(), e);
 		}

--- a/src/main/java/com/threestar/trainus/domain/user/controller/UserController.java
+++ b/src/main/java/com/threestar/trainus/domain/user/controller/UserController.java
@@ -19,6 +19,7 @@ import com.threestar.trainus.domain.user.service.EmailVerificationService;
 import com.threestar.trainus.domain.user.service.UserService;
 import com.threestar.trainus.global.unit.BaseResponse;
 
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
@@ -34,6 +35,7 @@ public class UserController {
 	private final EmailVerificationService emailVerificationService;
 
 	@PostMapping("/signup")
+	@Operation(summary = "회원가입 api")
 	public ResponseEntity<BaseResponse<SignupResponseDto>> signup(
 		@Valid @RequestBody SignupRequestDto request
 	) {
@@ -43,6 +45,7 @@ public class UserController {
 	}
 
 	@PostMapping("/login")
+	@Operation(summary = "로그인 api")
 	public ResponseEntity<BaseResponse<LoginResponseDto>> login(
 		@Valid @RequestBody LoginRequestDto request,
 		HttpSession session
@@ -52,12 +55,14 @@ public class UserController {
 	}
 
 	@PostMapping("/logout")
+	@Operation(summary = "로그아웃 api")
 	public ResponseEntity<BaseResponse<Void>> logout(HttpSession session) {
 		userService.logout(session);
 		return BaseResponse.ok("로그아웃이 완료되었습니다.", null, HttpStatus.OK);
 	}
 
 	@PostMapping("/verify/check-nickname")
+	@Operation(summary = "닉네임 중복 체크 api")
 	public ResponseEntity<BaseResponse<Void>> checkNickname(
 		@Valid @RequestBody NicknameCheckRequestDto request
 	) {
@@ -66,6 +71,7 @@ public class UserController {
 	}
 
 	@PostMapping("/verify/email-send")
+	@Operation(summary = "이메일 인증코드 발송 api", description = "회원가입 중 이메일 인증 코드를 발송")
 	public ResponseEntity<BaseResponse<EmailSendResponseDto>> sendVerificationCode(
 		@Valid @RequestBody EmailSendRequestDto request
 	) {
@@ -74,6 +80,7 @@ public class UserController {
 	}
 
 	@PostMapping("/verify/email-check")
+	@Operation(summary = "이메일 인증코드 인증 api", description = "이메일 인증코드(6자리) 입력 시 인증 가능하고 나머지 회원가입 진행")
 	public ResponseEntity<BaseResponse<Void>> confirmVerificationCode(
 		@Valid @RequestBody EmailVerificationDto request
 	) {


### PR DESCRIPTION
## 🛠️ 작업 내용
1. 스웨거 api별 	@Operation 적용
2. 카테고리 별 랭킹 조회
<img width="605" height="803" alt="image" src="https://github.com/user-attachments/assets/59dba6ec-9958-4cbd-98e2-abd55369bd0b" />
<img width="647" height="778" alt="image" src="https://github.com/user-attachments/assets/d42ced0a-d16a-40f0-9c8d-1e66fa7fd976" />

3. Top10까지 조회 가능
4. 리뷰수 10개 이상 부터 랭킹 집계로 설정
5. 매 자정마다 랭킹 업데이트

   
## ✅ PR 유형
- [x] 새로운 기능 추가
- [ ] CSS 등 사용자 UI 디자인 변경
- [x] 코드 리팩토링
- [ ] 파일 혹은 폴더명 수정

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?

## 🔗 관련 이슈
- #74 

## 💬 기타 참고 사항
