### PR TITLE
refactor: 회원관련 수정

### DIFF
--- a/src/main/java/com/threestar/trainus/domain/lesson/teacher/repository/LessonApplicationRepository.java
+++ b/src/main/java/com/threestar/trainus/domain/lesson/teacher/repository/LessonApplicationRepository.java
@@ -1,5 +1,6 @@
 package com.threestar.trainus.domain.lesson.teacher.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.domain.Page;
@@ -25,6 +26,10 @@ public interface LessonApplicationRepository extends JpaRepository<LessonApplica
 	Optional<LessonApplication> findByLessonIdAndUserId(Long lessonId, Long userId);
 
 	Page<LessonApplication> findByUserId(Long userId, Pageable pageable);
+	
+	List<LessonApplication> findByUserId(Long userId);
+	
+	List<LessonApplication> findByLessonId(Long lessonId);
 
 	Page<LessonApplication> findByUserIdAndStatus(Long userId, ApplicationStatus status, Pageable pageable);
 }

--- a/src/main/java/com/threestar/trainus/domain/lesson/teacher/repository/LessonRepository.java
+++ b/src/main/java/com/threestar/trainus/domain/lesson/teacher/repository/LessonRepository.java
@@ -1,6 +1,7 @@
 package com.threestar.trainus.domain.lesson.teacher.repository;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.domain.Page;
@@ -60,6 +61,9 @@ public interface LessonRepository extends JpaRepository<Lesson, Long> {
 
 	// 강사가 개설한 레슨 목록 조회 (페이징)
 	Page<Lesson> findByLessonLeaderAndDeletedAtIsNull(Long lessonLeader, Pageable pageable);
+	
+	// 강사가 개설한 레슨 목록 조회 (전체 목록 - 탈퇴 검증용)
+	List<Lesson> findByLessonLeaderAndDeletedAtIsNull(Long lessonLeader);
 
 	// 강사가 개설한 레슨 목록 조회 (페이징+필터링)
 	Page<Lesson> findByLessonLeaderAndStatusAndDeletedAtIsNull(Long lessonLeader, LessonStatus status,

--- a/src/main/java/com/threestar/trainus/domain/user/controller/UserController.java
+++ b/src/main/java/com/threestar/trainus/domain/user/controller/UserController.java
@@ -2,6 +2,8 @@ package com.threestar.trainus.domain.user.controller;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -17,6 +19,7 @@ import com.threestar.trainus.domain.user.dto.NicknameCheckRequestDto;
 import com.threestar.trainus.domain.user.dto.PasswordUpdateDto;
 import com.threestar.trainus.domain.user.dto.SignupRequestDto;
 import com.threestar.trainus.domain.user.dto.SignupResponseDto;
+import com.threestar.trainus.domain.user.dto.UserInfoResponseDto;
 import com.threestar.trainus.domain.user.service.EmailVerificationService;
 import com.threestar.trainus.domain.user.service.UserService;
 import com.threestar.trainus.global.annotation.LoginUser;
@@ -111,11 +114,12 @@ public class UserController {
 	}
 
 	@DeleteMapping("/withdraw")
-	@Operation(summary = "회원탈퇴 api")
+	@Operation(summary = "회원탈퇴 api", description = "회원탈퇴 처리 및 관련 데이터 정리")
 	public ResponseEntity<BaseResponse<Void>> withdraw(
-		@LoginUser Long loginUserId
+		@LoginUser Long loginUserId,
+		HttpSession session
 	) {
-		userService.withdraw(loginUserId);
+		userService.withdraw(loginUserId, session);
 		return BaseResponse.okOnlyStatus(HttpStatus.NO_CONTENT);
 	}
 }

--- a/src/main/java/com/threestar/trainus/domain/user/dto/LoginResponseDto.java
+++ b/src/main/java/com/threestar/trainus/domain/user/dto/LoginResponseDto.java
@@ -1,9 +1,11 @@
 package com.threestar.trainus.domain.user.dto;
 
-public record LoginResponseDto(
+import com.threestar.trainus.domain.user.entity.UserRole;
 
+public record LoginResponseDto(
 	Long id,
 	String email,
-	String nickname
+	String nickname,
+	UserRole role
 ) {
 }

--- a/src/main/java/com/threestar/trainus/domain/user/dto/UserInfoResponseDto.java
+++ b/src/main/java/com/threestar/trainus/domain/user/dto/UserInfoResponseDto.java
@@ -2,6 +2,7 @@ package com.threestar.trainus.domain.user.dto;
 
 public record UserInfoResponseDto(
 	Long userId,
-	String nickname
+	String nickname,
+	String email
 ) {
 }

--- a/src/main/java/com/threestar/trainus/domain/user/dto/UserInfoResponseDto.java
+++ b/src/main/java/com/threestar/trainus/domain/user/dto/UserInfoResponseDto.java
@@ -1,8 +1,11 @@
 package com.threestar.trainus.domain.user.dto;
 
+import com.threestar.trainus.domain.user.entity.UserRole;
+
 public record UserInfoResponseDto(
 	Long userId,
 	String nickname,
-	String email
+	String email,
+	UserRole role
 ) {
 }

--- a/src/main/java/com/threestar/trainus/domain/user/entity/User.java
+++ b/src/main/java/com/threestar/trainus/domain/user/entity/User.java
@@ -72,4 +72,9 @@ public class User extends BaseDateEntity {
 	public void withdraw() {
 		this.deletedAt = LocalDateTime.now();
 	}
+
+	public void anonymizePersonalData(String anonymizedNickname) {
+		this.nickname = anonymizedNickname;
+	}
+
 }

--- a/src/main/java/com/threestar/trainus/domain/user/mapper/UserMapper.java
+++ b/src/main/java/com/threestar/trainus/domain/user/mapper/UserMapper.java
@@ -36,7 +36,8 @@ public class UserMapper {
 		return new LoginResponseDto(
 			user.getId(),
 			user.getEmail(),
-			user.getNickname()
+			user.getNickname(),
+			user.getRole()
 		);
 	}
 
@@ -44,7 +45,8 @@ public class UserMapper {
 		return new UserInfoResponseDto(
 			user.getId(),
 			user.getNickname(),
-			user.getEmail()
+			user.getEmail(),
+			user.getRole()
 		);
 	}
 }

--- a/src/main/java/com/threestar/trainus/domain/user/mapper/UserMapper.java
+++ b/src/main/java/com/threestar/trainus/domain/user/mapper/UserMapper.java
@@ -43,7 +43,8 @@ public class UserMapper {
 	public static UserInfoResponseDto toUserInfoResponseDto(User user) {
 		return new UserInfoResponseDto(
 			user.getId(),
-			user.getNickname()
+			user.getNickname(),
+			user.getEmail()
 		);
 	}
 }

--- a/src/main/java/com/threestar/trainus/domain/user/service/UserService.java
+++ b/src/main/java/com/threestar/trainus/domain/user/service/UserService.java
@@ -1,6 +1,8 @@
 package com.threestar.trainus.domain.user.service;
 
+import java.time.LocalDateTime;
 import java.util.Collections;
+import java.util.List;
 
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -8,12 +10,18 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.threestar.trainus.domain.lesson.teacher.entity.Lesson;
+import com.threestar.trainus.domain.lesson.teacher.entity.LessonApplication;
+import com.threestar.trainus.domain.lesson.teacher.entity.LessonStatus;
+import com.threestar.trainus.domain.lesson.teacher.repository.LessonApplicationRepository;
+import com.threestar.trainus.domain.lesson.teacher.repository.LessonRepository;
 import com.threestar.trainus.domain.profile.service.ProfileFacadeService;
 import com.threestar.trainus.domain.user.dto.LoginRequestDto;
 import com.threestar.trainus.domain.user.dto.LoginResponseDto;
 import com.threestar.trainus.domain.user.dto.PasswordUpdateDto;
 import com.threestar.trainus.domain.user.dto.SignupRequestDto;
 import com.threestar.trainus.domain.user.dto.SignupResponseDto;
+import com.threestar.trainus.domain.user.dto.UserInfoResponseDto;
 import com.threestar.trainus.domain.user.entity.User;
 import com.threestar.trainus.domain.user.entity.UserRole;
 import com.threestar.trainus.domain.user.mapper.UserMapper;
@@ -23,7 +31,9 @@ import com.threestar.trainus.global.exception.handler.BusinessException;
 
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class UserService {
@@ -32,6 +42,8 @@ public class UserService {
 	private final PasswordEncoder passwordEncoder;
 	private final ProfileFacadeService facadeService;
 	private final EmailVerificationService emailVerificationService;
+	private final LessonRepository lessonRepository;
+	private final LessonApplicationRepository lessonApplicationRepository;
 
 	@Transactional
 	public SignupResponseDto signup(SignupRequestDto request) {
@@ -140,10 +152,63 @@ public class UserService {
 	}
 
 	@Transactional
-	public void withdraw(Long userId) {
+	public void withdraw(Long userId, HttpSession session) {
 		User user = getUserById(userId);
 
+		//강사는 탈퇴 불가 (레슨 있을 시)
+		validateInstructorCanWithdraw(user);
+
+		//사용자의 활성 레슨 신청이 있으면 탈퇴 불가
+		validateUserHasNoActiveApplications(user);
+
+		//개인정보 비식별화
+		String anonymizedNickname = "탈퇴한사용자" + user.getId();
+
+		user.anonymizePersonalData( anonymizedNickname);
+
 		user.withdraw();
+		userRepository.save(user);
+
+		invalidateUserSession(session);
+	}
+
+	private void validateInstructorCanWithdraw(User user) {
+		List<Lesson> instructorLessons = lessonRepository.findByLessonLeaderAndDeletedAtIsNull(user.getId());
+
+		if (!instructorLessons.isEmpty()) {
+			throw new BusinessException(ErrorCode.INSTRUCTOR_HAS_LESSONS);
+		}
+	}
+
+	private void validateUserHasNoActiveApplications(User user) {
+		List<LessonApplication> applications = lessonApplicationRepository.findByUserId(user.getId());
+
+		if (applications.isEmpty()) {
+			return;
+		}
+
+		LocalDateTime now = LocalDateTime.now();
+		long activeApplicationsCount = applications.stream()
+			.filter(application -> application.getLesson().getStartAt().isAfter(now))
+			.count();
+
+		if (activeApplicationsCount > 0) {
+			throw new BusinessException(ErrorCode.USER_HAS_ACTIVE_APPLICATIONS);
+		}
+	}
+
+	private void invalidateUserSession(HttpSession session) {
+		try {
+			// 세션 무효화
+			if (session != null) {
+				session.invalidate();
+			}
+
+			// Spring Security 컨텍스트 정리
+			SecurityContextHolder.clearContext();
+		} catch (Exception e) {
+			// 세션 무효화 실패해도 탈퇴는 진행
+		}
 	}
 
 	@Transactional(readOnly = true)

--- a/src/main/java/com/threestar/trainus/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/threestar/trainus/global/config/security/SecurityConfig.java
@@ -27,7 +27,7 @@ public class SecurityConfig {
 			.authorizeHttpRequests(auth -> auth
 				.requestMatchers("/api/v1/users/**", "/api/lessons/test-auth", "/swagger-ui/**", "/v3/api-docs/**",
 					"/api/v1/profiles/**", "/api/v1/lessons/**", "/api/v1/comments/**", "/api/v1/reviews/**"
-					, "/api/v1/rankings/**", "/api/v1/payments/**")
+					, "/api/v1/rankings/**", "/api/v1/payments/**", "/api/v1/admin/**")
 				.permitAll()
 				.anyRequest()
 				.authenticated()

--- a/src/main/java/com/threestar/trainus/global/exception/domain/ErrorCode.java
+++ b/src/main/java/com/threestar/trainus/global/exception/domain/ErrorCode.java
@@ -112,6 +112,10 @@ public enum ErrorCode {
 	EMAIL_SEND_FAILED(HttpStatus.BAD_REQUEST, "이메일 발송을 실패했습니다."),
 
 	EMAIL_SEND_TOO_FREQUENT(HttpStatus.TOO_MANY_REQUESTS, "이메일 발송은 1분에 한 번만 가능합니다."),
+
+	INSTRUCTOR_HAS_LESSONS(HttpStatus.BAD_REQUEST, "등록된 레슨이 있는 강사는 탈퇴할 수 없습니다. 먼저 모든 레슨을 삭제해주세요."),
+
+	USER_HAS_ACTIVE_APPLICATIONS(HttpStatus.BAD_REQUEST, "참여 중인 레슨이 있어 탈퇴할 수 없습니다."),
 	/*
 	 * Profile : 프로필 관련 예외처리
 	 */


### PR DESCRIPTION
## 🛠️ 작업 내용
1. 회원 탈퇴 로직 수정 (레슨 참여 강사, 회원은 탈퇴 불가, 탈퇴한 회원은 닉네임 "탈퇴한사용자" 처리, 세션 무효화)
2. 회원 정보 조회 api email 필드 추가
3. 회원 관련 api응답에 user의 role추가

## ✅ PR 유형
- [x] 새로운 기능 추가
- [ ] CSS 등 사용자 UI 디자인 변경
- [x] 코드 리팩토링
- [ ] 파일 혹은 폴더명 수정

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?

## 🔗 관련 이슈
- #129 

## 💬 기타 참고 사항
