### PR TITLE
fix : 랭킹 카테고리 조회 메타데이터 사용 , 랭킹 캐싱 ttl 11분으로 교체

### DIFF
--- a/src/main/java/com/threestar/trainus/domain/ranking/repository/RankingRepository.java
+++ b/src/main/java/com/threestar/trainus/domain/ranking/repository/RankingRepository.java
@@ -31,22 +31,25 @@ public interface RankingRepository extends JpaRepository<ProfileMetadata, Long> 
 	List<RankingData> findTopRankings();
 
 	@Query("""
-		SELECT r.reviewee.id as userId,
-			r.reviewee.nickname as userNickname,
-			CAST(COUNT(r.reviewId) AS INTEGER) as reviewCount,
-			CAST(AVG(r.rating) AS DOUBLE) as rating,
-			p.profileImage as profileImage
-		FROM Review r
-		JOIN r.lesson l
-		JOIN r.reviewee u
+		SELECT pm.user.id as userId,
+		    pm.user.nickname as userNickname,
+		    pm.reviewCount as reviewCount,
+		    pm.rating as rating,
+		    p.profileImage as profileImage
+		FROM ProfileMetadata pm
+		JOIN pm.user u
 		LEFT JOIN Profile p ON p.user = u
-		WHERE l.category = :category
-		AND r.deletedAt IS NULL
-		GROUP BY r.reviewee.id, r.reviewee.nickname, p.profileImage
-		HAVING COUNT(r.reviewId) >= 5
+		WHERE pm.reviewCount >= 5
+		AND EXISTS (
+		    SELECT 1 FROM Review r 
+		    JOIN r.lesson l 
+		    WHERE r.reviewee = u 
+		    AND l.category = :category 
+		    AND r.deletedAt IS NULL
+		)
 		ORDER BY (
-			(AVG(r.rating) / 5.0) * 0.5 +
-			(LEAST(COUNT(r.reviewId), 100) / 100.0) * 0.5
+		    (pm.rating / 5.0) * 0.5 +
+		    (LEAST(pm.reviewCount, 100) / 100.0) * 0.5
 		) DESC
 		LIMIT 10
 		""")

--- a/src/main/java/com/threestar/trainus/domain/ranking/service/RankingService.java
+++ b/src/main/java/com/threestar/trainus/domain/ranking/service/RankingService.java
@@ -90,7 +90,7 @@ public class RankingService {
 	private void saveToRedis(List<RankingResponseDto> rankings, String cacheKey) {
 		try {
 			String json = objectMapper.writeValueAsString(rankings);
-			redisTemplate.opsForValue().set(cacheKey, json, Duration.ofHours(24));
+			redisTemplate.opsForValue().set(cacheKey, json, Duration.ofMinutes(11));
 		} catch (Exception e) {
 			log.warn("Redis 저장 실패: {}", e.getMessage());
 		}


### PR DESCRIPTION
## 🛠️ 작업 내용
1. 랭킹 카테고리 조회 메타데이터 사용 (리뷰에서 실제 조회하고 있었음)
2. 랭킹 캐싱 TTL 24시간 -> 11분 (10분마다 업데이트 하므로 11분으로 두는 것이 좋다고 함)
   
## ✅ PR 유형
- [ ] 새로운 기능 추가
- [ ] CSS 등 사용자 UI 디자인 변경
- [x] 코드 리팩토링
- [ ] 파일 혹은 폴더명 수정

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?

## 🔗 관련 이슈
- 

## 💬 기타 참고 사항
