### PR TITLE
chore: 프로필 메타데이터 스케줄 임시 조정 (부하 테스트)

### DIFF
--- a/src/main/java/com/threestar/trainus/domain/metadata/scheduler/ProfileMetadataScheduler.java
+++ b/src/main/java/com/threestar/trainus/domain/metadata/scheduler/ProfileMetadataScheduler.java
@@ -22,7 +22,7 @@ public class ProfileMetadataScheduler {
 	private final ProfileMetadataService profileMetadataService;
 	private final UserRepository userRepository;
 
-	@Scheduled(fixedRate = 180000) // 3분마다 실행
+	@Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul") // 매일 자정 실행
 	public void updateAllProfileMetadata() {
 		try {
 			List<User> instructors = userRepository.findByRole(UserRole.USER);


### PR DESCRIPTION
## 🛠️ 작업 내용
- 프로필 메타데이터 스케줄 임시 조정
   
## ✅ PR 유형
- [x] 코드 리팩토링

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?

## 🔗 관련 이슈
- #180 

## 💬 기타 참고 사항
기존 3분마다 실행되던 프로필 메타데이터 배치 작업을 한국 시간 기준 매일 자정 1회 실행으로 변경하였습니다.
시스템 부하 테스트 진행 시 메타데이터 업데이트로 인한 추가적인 부하를 줄이고 테스트 환경의 안정성을 확보하기 위함입니다.
