### PR TITLE
feat: 레디스 재고필터+메시지 큐 쿠폰 발급

### DIFF
--- a/src/main/java/com/threestar/trainus/domain/coupon/admin/controller/AdminCouponController.java
+++ b/src/main/java/com/threestar/trainus/domain/coupon/admin/controller/AdminCouponController.java
@@ -1,5 +1,6 @@
 package com.threestar.trainus.domain.coupon.admin.controller;
 
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -23,6 +24,7 @@ import com.threestar.trainus.domain.coupon.admin.dto.CouponUpdateRequestDto;
 import com.threestar.trainus.domain.coupon.admin.dto.CouponUpdateResponseDto;
 import com.threestar.trainus.domain.coupon.admin.mapper.AdminCouponMapper;
 import com.threestar.trainus.domain.coupon.admin.service.AdminCouponService;
+import com.threestar.trainus.domain.coupon.user.entity.Coupon;
 import com.threestar.trainus.domain.coupon.user.entity.CouponCategory;
 import com.threestar.trainus.domain.coupon.user.entity.CouponStatus;
 import com.threestar.trainus.global.annotation.LoginUser;
@@ -42,6 +44,7 @@ import lombok.RequiredArgsConstructor;
 public class AdminCouponController {
 
 	private final AdminCouponService adminCouponService;
+	private final StringRedisTemplate redisTemplate;
 
 	@PostMapping
 	@Operation(summary = "쿠폰 생성", description = "관리자가 새로운 쿠폰을 생성")
@@ -51,6 +54,25 @@ public class AdminCouponController {
 	) {
 		CouponCreateResponseDto response = adminCouponService.createCoupon(request, loginUserId);
 		return BaseResponse.ok("쿠폰 생성이 완료되었습니다.", response, HttpStatus.OK);
+	}
+
+	/**
+	 레디스 재고 세팅용 테스트 컨트롤러
+	 Todo:실제 쿠폰생성 로직에 병합
+	 */
+	@PostMapping("/setting/redis/{couponId}")
+	public ResponseEntity<Void> settingRedisStock(
+		@PathVariable Long couponId
+	) {
+
+		Coupon coupon = adminCouponService.findCouponById(couponId);
+
+		redisTemplate.opsForValue().set(
+			"coupon:stock:" + couponId,
+			coupon.getQuantity().toString()
+		);
+
+		return ResponseEntity.ok().build();
 	}
 
 	@GetMapping

--- a/src/main/java/com/threestar/trainus/domain/coupon/issue/CouponIssueConsumer.java
+++ b/src/main/java/com/threestar/trainus/domain/coupon/issue/CouponIssueConsumer.java
@@ -1,0 +1,142 @@
+package com.threestar.trainus.domain.coupon.issue;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.data.redis.connection.stream.Consumer;
+import org.springframework.data.redis.connection.stream.MapRecord;
+import org.springframework.data.redis.connection.stream.PendingMessagesSummary;
+import org.springframework.data.redis.connection.stream.ReadOffset;
+import org.springframework.data.redis.connection.stream.StreamOffset;
+import org.springframework.data.redis.connection.stream.StreamReadOptions;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CouponIssueConsumer {
+
+	private final StringRedisTemplate redisTemplate;
+	private final CouponIssueService couponIssueService;
+
+	private static final String STREAM_KEY = "coupon.issue.stream";
+	private static final String GROUP = "coupon.issue.group";
+	private static final String CONSUMER = "consumer-" + UUID.randomUUID();
+	private static final String STOCK_KEY = "coupon:stock:";
+
+	@PostConstruct
+	public void init() {
+		createGroupIfNotExists();
+		startConsumerThread();
+	}
+
+	private void startConsumerThread() {
+		Thread consumerThread = new Thread(() -> {
+			while (true) {
+				try {
+					consumeNewMessages();
+					handlePendingMessages();
+
+				} catch (Exception e) {
+
+				}
+			}
+		});
+
+		consumerThread.setName("coupon-stream-consumer-thread");
+		consumerThread.start();
+	}
+
+	private void consumeNewMessages() {
+		List<MapRecord<String, Object, Object>> messages = redisTemplate.opsForStream().read(
+			Consumer.from(GROUP, CONSUMER),
+			StreamReadOptions.empty().count(10).block(Duration.ofSeconds(2)),
+			StreamOffset.create(STREAM_KEY, ReadOffset.lastConsumed())
+		);
+
+		if (messages == null || messages.isEmpty())
+			return;
+
+		for (MapRecord<String, Object, Object> message : messages) {
+			process(message);
+		}
+	}
+
+	private void handlePendingMessages() {
+		// pending이 없으면 skip 가능하도록
+		PendingMessagesSummary pending = redisTemplate.opsForStream()
+			.pending(STREAM_KEY, GROUP);
+
+		if (pending == null || pending.getTotalPendingMessages() == 0)
+			return;
+
+		List<MapRecord<String, Object, Object>> pendingList =
+			redisTemplate.opsForStream().read(
+				Consumer.from(GROUP, CONSUMER),
+				StreamReadOptions.empty().count(10),
+				StreamOffset.create(STREAM_KEY, ReadOffset.from("0"))
+			);
+
+		if (pendingList == null)
+			return;
+
+		for (MapRecord<String, Object, Object> message : pendingList) {
+			process(message);
+		}
+	}
+
+	private void process(MapRecord<String, Object, Object> message) {
+		Long couponId = null;
+		Long userId = null;
+		try {
+			couponId = Long.valueOf(message.getValue().get("couponId").toString());
+			userId = Long.valueOf(message.getValue().get("userId").toString());
+
+			log.info("CONSUME coupon={} user={}", couponId, userId);
+
+			boolean issued = couponIssueService.issue(couponId, userId);
+
+			if (issued) {
+				//정상 발급, DB quantity 감소처리
+				redisTemplate.opsForStream().acknowledge(STREAM_KEY, GROUP, message.getId());
+				return;
+			}
+
+			//발급 오류
+			rollbackStock(couponId);
+			redisTemplate.opsForStream().acknowledge(STREAM_KEY, GROUP, message.getId());
+		} catch (Exception e) {
+			log.error("Issue failed: {}, message stays in PENDING", e.getMessage());
+		}
+	}
+
+	private void rollbackStock(Long couponId) {
+		String stockKey = STOCK_KEY + couponId;
+		redisTemplate.opsForValue().increment(stockKey);
+	}
+
+	private void createGroupIfNotExists() {
+		try {
+			redisTemplate.opsForStream().createGroup(STREAM_KEY, GROUP);
+			log.info("Redis stream group created");
+		} catch (Exception e) {
+			// 그룹 이미 있으면 예외 발생함 (무시)
+			log.info("Redis stream group already exists");
+		}
+	}
+
+	public void testConsumeOnce() {
+		try {
+			consumeNewMessages();
+			handlePendingMessages();
+		} catch (Exception e) {
+			log.error("Manual consume failed: {}", e.getMessage());
+		}
+	}
+}

--- a/src/main/java/com/threestar/trainus/domain/coupon/issue/CouponIssueConsumer.java
+++ b/src/main/java/com/threestar/trainus/domain/coupon/issue/CouponIssueConsumer.java
@@ -16,7 +16,9 @@ import org.springframework.stereotype.Component;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Profile;
 
+@Profile("consumer")
 @Slf4j
 @Component
 @RequiredArgsConstructor

--- a/src/main/java/com/threestar/trainus/domain/coupon/issue/CouponIssueProducer.java
+++ b/src/main/java/com/threestar/trainus/domain/coupon/issue/CouponIssueProducer.java
@@ -1,0 +1,42 @@
+package com.threestar.trainus.domain.coupon.issue;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CouponIssueProducer {
+
+	private static final String STREAM_KEY = CouponIssueStreamConstant.STREAM_KEY;
+	private static final String STOCK_KEY_PREFIX = "coupon:stock:";
+
+	private final StringRedisTemplate stringRedisTemplate;
+
+	public CouponIssueProducer(StringRedisTemplate stringRedisTemplate) {
+		this.stringRedisTemplate = stringRedisTemplate;
+	}
+
+	public boolean send(Long couponId, Long userId) {
+		String stockKey = STOCK_KEY_PREFIX + couponId;
+
+		Long stock = stringRedisTemplate.opsForValue().decrement(stockKey);
+
+		if (stock == null) {
+			return false;
+		}
+
+		if (stock < 0) {
+			stringRedisTemplate.opsForValue().increment(stockKey);
+			return false;
+		}
+		Map<String, String> message = new HashMap<>();
+		message.put("couponId", couponId.toString());
+		message.put("userId", userId.toString());
+
+		stringRedisTemplate.opsForStream()
+			.add(STREAM_KEY, message);
+		return true;
+	}
+}

--- a/src/main/java/com/threestar/trainus/domain/coupon/issue/CouponIssueService.java
+++ b/src/main/java/com/threestar/trainus/domain/coupon/issue/CouponIssueService.java
@@ -1,0 +1,46 @@
+package com.threestar.trainus.domain.coupon.issue;
+
+import java.time.LocalDateTime;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.threestar.trainus.domain.coupon.user.entity.Coupon;
+import com.threestar.trainus.domain.coupon.user.entity.UserCoupon;
+import com.threestar.trainus.domain.coupon.user.repository.CouponRepository;
+import com.threestar.trainus.domain.coupon.user.repository.UserCouponRepository;
+import com.threestar.trainus.domain.user.entity.User;
+import com.threestar.trainus.domain.user.service.UserService;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class CouponIssueService {
+	private final CouponRepository couponRepository;
+	private final UserCouponRepository userCouponRepository;
+	private final UserService userService;
+
+	@Transactional
+	public boolean issue(Long couponId, Long userId) {
+		//1.멱등처리(이미 발급된 경우)
+		if (userCouponRepository.existsByUserIdAndCouponId(userId, couponId)) {
+			return false;
+		}
+		User user = userService.getUserById(userId);
+		Coupon coupon = couponRepository.findById(couponId).orElseThrow();
+
+		//2. 시간 검증
+		if (LocalDateTime.now().isBefore(coupon.getOpenAt())) {
+			return false;
+		}
+		if (LocalDateTime.now().isAfter(coupon.getCloseAt())) {
+			return false;
+		}
+
+		userCouponRepository.save(new UserCoupon(user, coupon, coupon.getExpirationDate()));
+		coupon.decreaseQuantity();
+
+		return true;
+	}
+}

--- a/src/main/java/com/threestar/trainus/domain/coupon/issue/CouponIssueStreamConstant.java
+++ b/src/main/java/com/threestar/trainus/domain/coupon/issue/CouponIssueStreamConstant.java
@@ -1,0 +1,9 @@
+package com.threestar.trainus.domain.coupon.issue;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class CouponIssueStreamConstant {
+	public static final String STREAM_KEY = "coupon.issue.stream";
+	public static final String GROUP = "coupon.issue.group";
+}

--- a/src/main/java/com/threestar/trainus/domain/coupon/user/controller/CouponController.java
+++ b/src/main/java/com/threestar/trainus/domain/coupon/user/controller/CouponController.java
@@ -5,6 +5,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -16,6 +17,7 @@ import com.threestar.trainus.domain.coupon.user.dto.CreateUserCouponResponseDto;
 import com.threestar.trainus.domain.coupon.user.dto.UserCouponPageResponseDto;
 import com.threestar.trainus.domain.coupon.user.entity.CouponStatus;
 import com.threestar.trainus.domain.coupon.user.service.CouponService;
+import com.threestar.trainus.domain.test.dto.TestRequestDto;
 import com.threestar.trainus.global.annotation.LoginUser;
 import com.threestar.trainus.global.unit.BaseResponse;
 
@@ -69,10 +71,10 @@ public class CouponController {
 	 * */
 	@PostMapping("/{couponId}/issue")
 	public ResponseEntity<Void> issueCoupon(
-		@RequestParam Long userId,
+		@RequestBody TestRequestDto testRequestDto,
 		@PathVariable Long couponId
 	) {
-		couponIssueProducer.send(couponId, userId);
+		couponIssueProducer.send(couponId, testRequestDto.getUserId());
 
 		return ResponseEntity.accepted().build(); // 202
 	}

--- a/src/main/java/com/threestar/trainus/domain/coupon/user/controller/CouponController.java
+++ b/src/main/java/com/threestar/trainus/domain/coupon/user/controller/CouponController.java
@@ -9,6 +9,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.threestar.trainus.domain.coupon.issue.CouponIssueConsumer;
+import com.threestar.trainus.domain.coupon.issue.CouponIssueProducer;
 import com.threestar.trainus.domain.coupon.user.dto.CouponPageResponseDto;
 import com.threestar.trainus.domain.coupon.user.dto.CreateUserCouponResponseDto;
 import com.threestar.trainus.domain.coupon.user.dto.UserCouponPageResponseDto;
@@ -28,6 +30,8 @@ import lombok.RequiredArgsConstructor;
 public class CouponController {
 
 	private final CouponService couponService;
+	private final CouponIssueProducer couponIssueProducer;
+	private final CouponIssueConsumer couponIssueConsumer;
 
 	@PostMapping("/{couponId}")
 	@Operation(summary = "쿠폰 발급 API", description = "couponId에 맞는 쿠폰을 유저에게 발급하는 API입니다.")
@@ -57,5 +61,29 @@ public class CouponController {
 		CouponPageResponseDto dto = couponService.getCoupons(userId);
 
 		return BaseResponse.ok("발급가능한 쿠폰 조회 성공", dto, HttpStatus.OK);
+	}
+
+	/**
+	 * 임시 테스트용 메서드
+	 * Todo: 불필요한 컨트롤러. 삭제해도 무방
+	 * */
+	@PostMapping("/{couponId}/issue")
+	public ResponseEntity<Void> issueCoupon(
+		@RequestParam Long userId,
+		@PathVariable Long couponId
+	) {
+		couponIssueProducer.send(couponId, userId);
+
+		return ResponseEntity.accepted().build(); // 202
+	}
+
+	/**
+	 * 임시 테스트용 메서드
+	 * Todo: 불필요한 컨트롤러. 삭제해도 무방
+	 * */
+	@PostMapping("/consume")
+	public ResponseEntity<String> manualConsume() {
+		couponIssueConsumer.testConsumeOnce();
+		return ResponseEntity.ok("Manual consume executed");
 	}
 }

--- a/src/main/java/com/threestar/trainus/domain/coupon/user/controller/CouponController.java
+++ b/src/main/java/com/threestar/trainus/domain/coupon/user/controller/CouponController.java
@@ -1,5 +1,6 @@
 package com.threestar.trainus.domain.coupon.user.controller;
 
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -69,6 +70,7 @@ public class CouponController {
 	 * 임시 테스트용 메서드
 	 * Todo: 불필요한 컨트롤러. 삭제해도 무방
 	 * */
+	@Profile("producer")
 	@PostMapping("/{couponId}/issue")
 	public ResponseEntity<Void> issueCoupon(
 		@RequestBody TestRequestDto testRequestDto,

--- a/src/main/java/com/threestar/trainus/domain/coupon/user/controller/CouponController.java
+++ b/src/main/java/com/threestar/trainus/domain/coupon/user/controller/CouponController.java
@@ -1,5 +1,7 @@
 package com.threestar.trainus.domain.coupon.user.controller;
 
+import com.threestar.trainus.domain.coupon.user.service.CouponIssueFacade;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -33,8 +35,10 @@ import lombok.RequiredArgsConstructor;
 public class CouponController {
 
 	private final CouponService couponService;
+	private final CouponIssueFacade couponIssueFacade;
 	private final CouponIssueProducer couponIssueProducer;
-	private final CouponIssueConsumer couponIssueConsumer;
+	@Autowired(required = false)
+	private CouponIssueConsumer couponIssueConsumer;
 
 	@PostMapping("/{couponId}")
 	@Operation(summary = "쿠폰 발급 API", description = "couponId에 맞는 쿠폰을 유저에게 발급하는 API입니다.")
@@ -42,7 +46,7 @@ public class CouponController {
 		@PathVariable Long couponId,
 		@LoginUser Long userId
 	) {
-		CreateUserCouponResponseDto dto = couponService.createUserCouponWithDistributedLock(userId, couponId);
+		CreateUserCouponResponseDto dto = couponIssueFacade.issueCoupon(userId, couponId);
 
 		return BaseResponse.ok("쿠폰 발급 완료", dto, HttpStatus.CREATED);
 	}
@@ -87,6 +91,9 @@ public class CouponController {
 	 * */
 	@PostMapping("/consume")
 	public ResponseEntity<String> manualConsume() {
+		if (couponIssueConsumer == null) {
+			return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).body("Consumer is not active.");
+		}
 		couponIssueConsumer.testConsumeOnce();
 		return ResponseEntity.ok("Manual consume executed");
 	}

--- a/src/main/java/com/threestar/trainus/domain/coupon/user/service/CouponIssueFacade.java
+++ b/src/main/java/com/threestar/trainus/domain/coupon/user/service/CouponIssueFacade.java
@@ -1,0 +1,20 @@
+package com.threestar.trainus.domain.coupon.user.service;
+
+import com.threestar.trainus.domain.coupon.user.dto.CreateUserCouponResponseDto;
+import com.threestar.trainus.global.annotation.DistributedLock;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CouponIssueFacade {
+
+	private final CouponService couponService;
+
+	@DistributedLock(key = "'coupon:' + #couponId")
+	public CreateUserCouponResponseDto issueCoupon(Long userId, Long couponId) {
+		return couponService.issueCoupon(userId, couponId);
+	}
+}

--- a/src/main/java/com/threestar/trainus/domain/coupon/user/service/CouponService.java
+++ b/src/main/java/com/threestar/trainus/domain/coupon/user/service/CouponService.java
@@ -106,13 +106,8 @@ public class CouponService {
 		return UserCouponMapper.toCreateUserCouponResponseDto(userCoupon);
 	}
 
-	@DistributedLock(key = "'coupon:' + #couponId")
-	public CreateUserCouponResponseDto createUserCouponWithDistributedLock(Long userId, Long couponId) {
-		return issueCouponInternal(userId, couponId);
-	}
-
 	@Transactional
-	public CreateUserCouponResponseDto issueCouponInternal(Long userId, Long couponId) {
+	public CreateUserCouponResponseDto issueCoupon(Long userId, Long couponId) {
 		User user = userService.getUserById(userId);
 		Coupon coupon = couponRepository.findById(couponId)
 			.orElseThrow(() -> new BusinessException(ErrorCode.COUPON_NOT_FOUND));

--- a/src/main/java/com/threestar/trainus/domain/coupon/user/service/CouponService.java
+++ b/src/main/java/com/threestar/trainus/domain/coupon/user/service/CouponService.java
@@ -106,12 +106,14 @@ public class CouponService {
 		return UserCouponMapper.toCreateUserCouponResponseDto(userCoupon);
 	}
 
-	@Transactional
 	@DistributedLock(key = "'coupon:' + #couponId")
 	public CreateUserCouponResponseDto createUserCouponWithDistributedLock(Long userId, Long couponId) {
+		return issueCouponInternal(userId, couponId);
+	}
+
+	@Transactional
+	public CreateUserCouponResponseDto issueCouponInternal(Long userId, Long couponId) {
 		User user = userService.getUserById(userId);
-		// Coupon coupon = couponRepository.findByIdWithPessimisticLock(couponId)
-		// 	.orElseThrow(() -> new BusinessException(ErrorCode.COUPON_NOT_FOUND));
 		Coupon coupon = couponRepository.findById(couponId)
 			.orElseThrow(() -> new BusinessException(ErrorCode.COUPON_NOT_FOUND));
 		// 쿠폰 발급 종료시각이 지났으면 예외처리

--- a/src/main/java/com/threestar/trainus/domain/test/controller/TestConcurrencyController.java
+++ b/src/main/java/com/threestar/trainus/domain/test/controller/TestConcurrencyController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.threestar.trainus.domain.coupon.issue.CouponIssueProducer;
 import com.threestar.trainus.domain.coupon.user.dto.CreateUserCouponResponseDto;
+import com.threestar.trainus.domain.coupon.user.service.CouponIssueFacade;
 import com.threestar.trainus.domain.coupon.user.service.CouponService;
 import com.threestar.trainus.domain.lesson.student.dto.LessonApplicationResponseDto;
 import com.threestar.trainus.domain.lesson.student.service.StudentLessonService;
@@ -33,6 +34,7 @@ public class TestConcurrencyController {
 	private final StudentLessonService studentLessonService;
 	private final TestUserService testUserService;
 	private final CouponIssueProducer couponIssueProducer;
+	private final CouponIssueFacade couponIssueFacade;
 
 	// 쿠폰 동시성 테스트
 	@PostMapping("/coupons/{couponId}/no-lock")
@@ -65,7 +67,7 @@ public class TestConcurrencyController {
 		@RequestBody TestRequestDto testRequestDto
 	) {
 		User user = testUserService.findOrCreateUser(testRequestDto.getUserId());
-		CreateUserCouponResponseDto responseDto = couponService.createUserCouponWithDistributedLock(user.getId(),
+		CreateUserCouponResponseDto responseDto = couponIssueFacade.issueCoupon(user.getId(),
 			couponId);
 		return BaseResponse.ok("쿠폰 발급 완료 (분산 락)", responseDto, HttpStatus.CREATED);
 	}

--- a/src/main/java/com/threestar/trainus/domain/test/controller/TestConcurrencyController.java
+++ b/src/main/java/com/threestar/trainus/domain/test/controller/TestConcurrencyController.java
@@ -1,5 +1,6 @@
 package com.threestar.trainus.domain.test.controller;
 
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -69,6 +70,7 @@ public class TestConcurrencyController {
 		return BaseResponse.ok("쿠폰 발급 완료 (분산 락)", responseDto, HttpStatus.CREATED);
 	}
 
+	@Profile("producer")
 	@PostMapping("/coupons/{couponId}/redis-stream")
 	@Operation(summary = "쿠폰 발급 동시성 테스트 (메시지 큐)", description = "쿠폰을 발급받는 테스트 API (메시지 큐)")
 	public ResponseEntity<?> issueCouponRedisStream(

--- a/src/main/java/com/threestar/trainus/domain/test/controller/TestConcurrencyController.java
+++ b/src/main/java/com/threestar/trainus/domain/test/controller/TestConcurrencyController.java
@@ -1,5 +1,14 @@
 package com.threestar.trainus.domain.test.controller;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.threestar.trainus.domain.coupon.issue.CouponIssueProducer;
 import com.threestar.trainus.domain.coupon.user.dto.CreateUserCouponResponseDto;
 import com.threestar.trainus.domain.coupon.user.service.CouponService;
 import com.threestar.trainus.domain.lesson.student.dto.LessonApplicationResponseDto;
@@ -13,10 +22,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
-
 @Tag(name = "동시성 테스트 API", description = "선착순 기능 테스트를 위한 API")
 @RestController
 @RequestMapping("/test")
@@ -26,6 +31,7 @@ public class TestConcurrencyController {
 	private final CouponService couponService;
 	private final StudentLessonService studentLessonService;
 	private final TestUserService testUserService;
+	private final CouponIssueProducer couponIssueProducer;
 
 	// 쿠폰 동시성 테스트
 	@PostMapping("/coupons/{couponId}/no-lock")
@@ -46,7 +52,8 @@ public class TestConcurrencyController {
 		@RequestBody TestRequestDto testRequestDto
 	) {
 		User user = testUserService.findOrCreateUser(testRequestDto.getUserId());
-		CreateUserCouponResponseDto responseDto = couponService.createUserCouponWithPessimisticLock(user.getId(), couponId);
+		CreateUserCouponResponseDto responseDto = couponService.createUserCouponWithPessimisticLock(user.getId(),
+			couponId);
 		return BaseResponse.ok("쿠폰 발급 완료 (비관적 락)", responseDto, HttpStatus.CREATED);
 	}
 
@@ -57,8 +64,23 @@ public class TestConcurrencyController {
 		@RequestBody TestRequestDto testRequestDto
 	) {
 		User user = testUserService.findOrCreateUser(testRequestDto.getUserId());
-		CreateUserCouponResponseDto responseDto = couponService.createUserCouponWithDistributedLock(user.getId(), couponId);
+		CreateUserCouponResponseDto responseDto = couponService.createUserCouponWithDistributedLock(user.getId(),
+			couponId);
 		return BaseResponse.ok("쿠폰 발급 완료 (분산 락)", responseDto, HttpStatus.CREATED);
+	}
+
+	@PostMapping("/coupons/{couponId}/redis-stream")
+	@Operation(summary = "쿠폰 발급 동시성 테스트 (메시지 큐)", description = "쿠폰을 발급받는 테스트 API (메시지 큐)")
+	public ResponseEntity<?> issueCouponRedisStream(
+		@PathVariable Long couponId,
+		@RequestBody TestRequestDto testRequestDto
+	) {
+		User user = testUserService.findOrCreateUser2(testRequestDto.getUserId());
+		boolean ok = couponIssueProducer.send(couponId, user.getId());
+		if (!ok) {
+			return ResponseEntity.status(HttpStatus.CONFLICT).body("sold out");
+		}
+		return ResponseEntity.accepted().build();
 	}
 
 	// 레슨 신청 동시성 테스트
@@ -80,7 +102,8 @@ public class TestConcurrencyController {
 		@RequestBody TestRequestDto testRequestDto
 	) {
 		User user = testUserService.findOrCreateUser(testRequestDto.getUserId());
-		LessonApplicationResponseDto response = studentLessonService.applyToLessonWithPessimisticLock(lessonId, user.getId());
+		LessonApplicationResponseDto response = studentLessonService.applyToLessonWithPessimisticLock(lessonId,
+			user.getId());
 		return BaseResponse.ok("레슨 신청 완료 (비관적 락)", response, HttpStatus.OK);
 	}
 
@@ -91,7 +114,9 @@ public class TestConcurrencyController {
 		@RequestBody TestRequestDto testRequestDto
 	) {
 		User user = testUserService.findOrCreateUser(testRequestDto.getUserId());
-		LessonApplicationResponseDto response = studentLessonService.applyToLessonWithDistributedLock(lessonId, user.getId());
+		LessonApplicationResponseDto response = studentLessonService.applyToLessonWithDistributedLock(lessonId,
+			user.getId());
 		return BaseResponse.ok("레슨 신청 완료 (분산 락)", response, HttpStatus.OK);
 	}
+
 }

--- a/src/main/java/com/threestar/trainus/domain/test/service/TestUserService.java
+++ b/src/main/java/com/threestar/trainus/domain/test/service/TestUserService.java
@@ -1,17 +1,17 @@
 package com.threestar.trainus.domain.test.service;
 
+import java.util.Optional;
+
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.threestar.trainus.domain.profile.service.ProfileFacadeService;
 import com.threestar.trainus.domain.user.entity.User;
 import com.threestar.trainus.domain.user.entity.UserRole;
 import com.threestar.trainus.domain.user.repository.UserRepository;
 
 import lombok.RequiredArgsConstructor;
-
-import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -48,4 +48,24 @@ public class TestUserService {
 
 		return savedUser;
 	}
+
+	@Transactional
+	public User findOrCreateUser2(Long userId) {
+
+		return userRepository.findByTestUserId(userId)
+			.orElseGet(() -> {
+				User user = User.builder()
+					.testUserId(userId)
+					.email("testuser" + userId + "@example.com")
+					.nickname("testuser" + userId)
+					.password(passwordEncoder.encode("password"))
+					.role(UserRole.USER)
+					.build();
+
+				User saved = userRepository.save(user);
+				profileFacadeService.createDefaultProfile(saved);
+				return saved;
+			});
+	}
+
 }

--- a/src/main/java/com/threestar/trainus/domain/user/entity/User.java
+++ b/src/main/java/com/threestar/trainus/domain/user/entity/User.java
@@ -41,6 +41,10 @@ public class User extends BaseDateEntity {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
+	//테스트용
+	@Column(unique = true, nullable = true)
+	private Long testUserId;
+
 	@Column(length = 100, nullable = false, unique = true)
 	private String email;
 

--- a/src/main/java/com/threestar/trainus/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/threestar/trainus/domain/user/repository/UserRepository.java
@@ -17,5 +17,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
 	Optional<User> findByEmail(String email);
 
 	List<User> findByRole(UserRole role);
+
+	Optional<User> findByTestUserId(Long id);
 }
 

--- a/src/main/java/com/threestar/trainus/global/config/RedisConfig.java
+++ b/src/main/java/com/threestar/trainus/global/config/RedisConfig.java
@@ -12,6 +12,7 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
@@ -28,7 +29,9 @@ public class RedisConfig {
 
 	@Value("${spring.data.redis.password:}")
 	private String password;
-
+	/**
+	 * 로컬 테스트용 프리픽스 -> spring.data.redis.key.prefix:redis://
+	 * */
 	@Value("${spring.data.redis.key.prefix}")
 	private String prefix;
 
@@ -67,5 +70,11 @@ public class RedisConfig {
 		redisTemplate.setValueSerializer(new StringRedisSerializer());
 		redisTemplate.setConnectionFactory(redisConnectionFactory());
 		return redisTemplate;
+	}
+
+	@Bean
+	public StringRedisTemplate stringRedisTemplate(
+		RedisConnectionFactory redisConnectionFactory) {
+		return new StringRedisTemplate(redisConnectionFactory);
 	}
 }

--- a/src/main/java/com/threestar/trainus/global/config/RedisStreamInitializer.java
+++ b/src/main/java/com/threestar/trainus/global/config/RedisStreamInitializer.java
@@ -1,0 +1,31 @@
+package com.threestar.trainus.global.config;
+
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+import com.threestar.trainus.domain.coupon.issue.CouponIssueStreamConstant;
+
+import jakarta.annotation.PostConstruct;
+
+@Component
+public class RedisStreamInitializer {
+
+	private static final String STREAM_KEY = CouponIssueStreamConstant.STREAM_KEY;
+	private static final String GROUP_NAME = CouponIssueStreamConstant.GROUP;
+
+	private final StringRedisTemplate stringRedisTemplate;
+
+	RedisStreamInitializer(StringRedisTemplate stringRedisTemplate) {
+		this.stringRedisTemplate = stringRedisTemplate;
+	}
+
+	@PostConstruct
+	public void init() {
+		try {
+			stringRedisTemplate.opsForStream()
+				.createGroup(STREAM_KEY, GROUP_NAME);
+		} catch (Exception e) {
+
+		}
+	}
+}

--- a/src/main/java/com/threestar/trainus/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/threestar/trainus/global/config/security/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.threestar.trainus.global.config.security;
 
 import java.util.List;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -30,7 +31,8 @@ public class SecurityConfig {
 		http
 			.authorizeHttpRequests(auth -> auth
 				.requestMatchers("/api/v1/users/**", "/api/lessons/test-auth", "/swagger-ui/**", "/v3/api-docs/**",
-					"/api/v1/profiles/**", "/api/v1/lessons/**", "/api/v1/comments/**", "/api/v1/reviews/**",
+					"/api/v1/profiles/**", "/api/v1/lessons/**", "api/v1/coupons/**", "/api/v1/comments/**",
+					"/api/v1/reviews/**", "/api/v1/admin/**",
 					"/api/v1/rankings/**", "/api/v1/payments/**", "/test/**", "/health")
 				.permitAll()
 				.requestMatchers("/api/v1/admin/**")


### PR DESCRIPTION
## 🛠️ 작업 내용
레디스 재고필터 + 메시지 큐 쿠폰 발급
Client → API → Redis.decr(재고필터) → Redis Stream → Consumer → DB

재고 체크는 produce 시점에 수행
쿠폰 중복 발급체크는 Consume 시점에 수행, 이 경우 차감된 redis 재고 반환

   
## ✅ PR 유형
- [x] 새로운 기능 추가
- [x] CSS 등 사용자 UI 디자인 변경
- [x] 코드 리팩토링
- [x] 파일 혹은 폴더명 수정

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?

## 🔗 관련 이슈
- 

## 💬 기타 참고 사항
