### PR TITLE
refactor: 세션 기반 사용자 인증을 JWT 무상태 인증으로 전면 교체

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,11 @@ dependencies {
 
     implementation 'org.redisson:redisson-spring-boot-starter:3.27.0' //Redisson
 
+    // JWT
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+
     testImplementation 'com.h2database:h2'
     testCompileOnly 'org.projectlombok:lombok' // 테스트 의존성 추가
     testAnnotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/threestar/trainus/domain/user/controller/UserController.java
+++ b/src/main/java/com/threestar/trainus/domain/user/controller/UserController.java
@@ -27,7 +27,6 @@ import com.threestar.trainus.global.unit.BaseResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
@@ -53,17 +52,16 @@ public class UserController {
 	@PostMapping("/login")
 	@Operation(summary = "로그인 api")
 	public ResponseEntity<BaseResponse<LoginResponseDto>> login(
-		@Valid @RequestBody LoginRequestDto request,
-		HttpSession session
+		@Valid @RequestBody LoginRequestDto request
 	) {
-		LoginResponseDto response = userService.login(request, session);
+		LoginResponseDto response = userService.login(request);
 		return BaseResponse.ok("로그인이 완료되었습니다", response, HttpStatus.OK);
 	}
 
 	@PostMapping("/logout")
 	@Operation(summary = "로그아웃 api")
-	public ResponseEntity<BaseResponse<Void>> logout(HttpSession session) {
-		userService.logout(session);
+	public ResponseEntity<BaseResponse<Void>> logout() {
+		userService.logout();
 		return BaseResponse.ok("로그아웃이 완료되었습니다.", null, HttpStatus.OK);
 	}
 
@@ -116,10 +114,9 @@ public class UserController {
 	@DeleteMapping("/withdraw")
 	@Operation(summary = "회원탈퇴 api", description = "회원탈퇴 처리 및 관련 데이터 정리")
 	public ResponseEntity<BaseResponse<Void>> withdraw(
-		@LoginUser Long loginUserId,
-		HttpSession session
+		@LoginUser Long loginUserId
 	) {
-		userService.withdraw(loginUserId, session);
+		userService.withdraw(loginUserId);
 		return BaseResponse.okOnlyStatus(HttpStatus.NO_CONTENT);
 	}
 }

--- a/src/main/java/com/threestar/trainus/domain/user/dto/LoginResponseDto.java
+++ b/src/main/java/com/threestar/trainus/domain/user/dto/LoginResponseDto.java
@@ -6,6 +6,8 @@ public record LoginResponseDto(
 	Long id,
 	String email,
 	String nickname,
-	UserRole role
+	UserRole role,
+	String accessToken,
+	String refreshToken
 ) {
 }

--- a/src/main/java/com/threestar/trainus/domain/user/mapper/UserMapper.java
+++ b/src/main/java/com/threestar/trainus/domain/user/mapper/UserMapper.java
@@ -32,12 +32,14 @@ public class UserMapper {
 		);
 	}
 
-	public static LoginResponseDto toLoginResponseDto(User user) {
+	public static LoginResponseDto toLoginResponseDto(User user, String accessToken, String refreshToken) {
 		return new LoginResponseDto(
 			user.getId(),
 			user.getEmail(),
 			user.getNickname(),
-			user.getRole()
+			user.getRole(),
+			accessToken,
+			refreshToken
 		);
 	}
 

--- a/src/main/java/com/threestar/trainus/domain/user/service/UserService.java
+++ b/src/main/java/com/threestar/trainus/domain/user/service/UserService.java
@@ -1,10 +1,8 @@
 package com.threestar.trainus.domain.user.service;
 
 import java.time.LocalDateTime;
-import java.util.Collections;
 import java.util.List;
 
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -12,7 +10,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.threestar.trainus.domain.lesson.teacher.entity.Lesson;
 import com.threestar.trainus.domain.lesson.teacher.entity.LessonApplication;
-import com.threestar.trainus.domain.lesson.teacher.entity.LessonStatus;
 import com.threestar.trainus.domain.lesson.teacher.repository.LessonApplicationRepository;
 import com.threestar.trainus.domain.lesson.teacher.repository.LessonRepository;
 import com.threestar.trainus.domain.profile.service.ProfileFacadeService;
@@ -26,10 +23,10 @@ import com.threestar.trainus.domain.user.entity.User;
 import com.threestar.trainus.domain.user.entity.UserRole;
 import com.threestar.trainus.domain.user.mapper.UserMapper;
 import com.threestar.trainus.domain.user.repository.UserRepository;
+import com.threestar.trainus.global.config.security.JwtProvider;
 import com.threestar.trainus.global.exception.domain.ErrorCode;
 import com.threestar.trainus.global.exception.handler.BusinessException;
 
-import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -44,34 +41,27 @@ public class UserService {
 	private final EmailVerificationService emailVerificationService;
 	private final LessonRepository lessonRepository;
 	private final LessonApplicationRepository lessonApplicationRepository;
+	private final JwtProvider jwtProvider;
 
 	@Transactional
 	public SignupResponseDto signup(SignupRequestDto request) {
-
 		if (!emailVerificationService.isEmailVerified(request.email())) {
 			throw new BusinessException(ErrorCode.EMAIL_NOT_VERIFIED);
 		}
-
 		if (userRepository.existsByEmail(request.email())) {
 			throw new BusinessException(ErrorCode.EMAIL_ALREADY_EXISTS);
 		}
-
 		if (userRepository.existsByNickname(request.nickname())) {
 			throw new BusinessException(ErrorCode.NICKNAME_ALREADY_EXISTS);
 		}
-
 		String encodedPassword = passwordEncoder.encode(request.password());
-
 		User newUser = userRepository.save(UserMapper.toEntity(request, encodedPassword));
-
-		facadeService.createDefaultProfile(newUser); //기본 프로필 생성.
-
+		facadeService.createDefaultProfile(newUser);
 		return UserMapper.toSignupResponseDto(newUser);
 	}
 
 	@Transactional(readOnly = true)
-	public LoginResponseDto login(LoginRequestDto request, HttpSession session) {
-
+	public LoginResponseDto login(LoginRequestDto request) {
 		User user = userRepository.findByEmail(request.email())
 			.orElseThrow(() -> new BusinessException(ErrorCode.INVALID_CREDENTIALS));
 
@@ -79,17 +69,15 @@ public class UserService {
 			throw new BusinessException(ErrorCode.INVALID_CREDENTIALS);
 		}
 
-		session.setAttribute("LOGIN_USER", user.getId());
+		String accessToken = jwtProvider.createAccessToken(user.getId(), user.getRole().name());
+		String refreshToken = jwtProvider.createRefreshToken(user.getId(), user.getRole().name());
 
-		UsernamePasswordAuthenticationToken authToken =
-			new UsernamePasswordAuthenticationToken(user.getId(), null, Collections.emptyList());
-		SecurityContextHolder.getContext().setAuthentication(authToken);
+		log.info("[JWT] Token issued for user: {}", user.getEmail());
 
-		return UserMapper.toLoginResponseDto(user);
+		return UserMapper.toLoginResponseDto(user, accessToken, refreshToken);
 	}
 
-	public void logout(HttpSession session) {
-		session.invalidate();
+	public void logout() {
 		SecurityContextHolder.clearContext();
 	}
 
@@ -102,8 +90,7 @@ public class UserService {
 
 	@Transactional(readOnly = true)
 	public User getUserById(Long userId) {
-		return userRepository.findById(userId)
-			.orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+		return userRepository.findById(userId).orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 	}
 
 	@Transactional(readOnly = true)
@@ -113,7 +100,6 @@ public class UserService {
 		}
 	}
 
-	//관리자 권한 검증
 	@Transactional(readOnly = true)
 	public void validateAdminRole(Long userId) {
 		User user = getUserById(userId);
@@ -122,7 +108,6 @@ public class UserService {
 		}
 	}
 
-	//사용자 조회 + 관리자 권한 검증
 	@Transactional(readOnly = true)
 	public User getAdminUser(Long userId) {
 		User user = getUserById(userId);
@@ -132,27 +117,24 @@ public class UserService {
 		return user;
 	}
 
+	@Transactional
 	public void updatePassword(PasswordUpdateDto request, Long userId) {
 		//새 비밀번호와 새 비밀번호 확인끼리의 검증
 		if (!request.newPassword().equals(request.confirmPassword())) {
 			throw new BusinessException(ErrorCode.INVALID_REQUEST_DATA);
 		}
-
 		User user = getUserById(userId);
 		//유저의 현재 비밀번호 검증
 		if (!passwordEncoder.matches(request.currentPassword(), user.getPassword())) {
 			throw new BusinessException(ErrorCode.INVALID_REQUEST_DATA);
 		}
-
-		String encordedNewPassword = passwordEncoder.encode(request.newPassword());
-
-		user.updatePassword(encordedNewPassword);
-
+		String encodedNewPassword = passwordEncoder.encode(request.newPassword());
+		user.updatePassword(encodedNewPassword);
 		userRepository.save(user);
 	}
 
 	@Transactional
-	public void withdraw(Long userId, HttpSession session) {
+	public void withdraw(Long userId) {
 		User user = getUserById(userId);
 
 		//강사는 탈퇴 불가 (레슨 있을 시)
@@ -163,18 +145,15 @@ public class UserService {
 
 		//개인정보 비식별화
 		String anonymizedNickname = "탈퇴한사용자" + user.getId();
-
-		user.anonymizePersonalData( anonymizedNickname);
-
+		user.anonymizePersonalData(anonymizedNickname);
 		user.withdraw();
 		userRepository.save(user);
 
-		invalidateUserSession(session);
+		SecurityContextHolder.clearContext();
 	}
 
 	private void validateInstructorCanWithdraw(User user) {
 		List<Lesson> instructorLessons = lessonRepository.findByLessonLeaderAndDeletedAtIsNull(user.getId());
-
 		if (!instructorLessons.isEmpty()) {
 			throw new BusinessException(ErrorCode.INSTRUCTOR_HAS_LESSONS);
 		}
@@ -182,32 +161,15 @@ public class UserService {
 
 	private void validateUserHasNoActiveApplications(User user) {
 		List<LessonApplication> applications = lessonApplicationRepository.findByUserId(user.getId());
-
 		if (applications.isEmpty()) {
 			return;
 		}
-
 		LocalDateTime now = LocalDateTime.now();
 		long activeApplicationsCount = applications.stream()
 			.filter(application -> application.getLesson().getStartAt().isAfter(now))
 			.count();
-
 		if (activeApplicationsCount > 0) {
 			throw new BusinessException(ErrorCode.USER_HAS_ACTIVE_APPLICATIONS);
-		}
-	}
-
-	private void invalidateUserSession(HttpSession session) {
-		try {
-			// 세션 무효화
-			if (session != null) {
-				session.invalidate();
-			}
-
-			// Spring Security 컨텍스트 정리
-			SecurityContextHolder.clearContext();
-		} catch (Exception e) {
-			// 세션 무효화 실패해도 탈퇴는 진행
 		}
 	}
 

--- a/src/main/java/com/threestar/trainus/global/config/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/threestar/trainus/global/config/security/JwtAuthenticationFilter.java
@@ -1,0 +1,55 @@
+package com.threestar.trainus.global.config.security;
+
+import java.io.IOException;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+	public static final String AUTHORIZATION_HEADER = "Authorization";
+	public static final String BEARER_PREFIX = "Bearer ";
+
+	private final JwtProvider jwtProvider;
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+		FilterChain filterChain) throws ServletException, IOException {
+
+		String jwt = resolveToken(request);
+		String requestUri = request.getRequestURI();
+
+		if (StringUtils.hasText(jwt) && jwtProvider.validateToken(jwt)) {
+			Authentication authentication = jwtProvider.getAuthentication(jwt);
+			SecurityContextHolder.getContext().setAuthentication(authentication);
+			log.info("[JWT AUTH] Success - Authenticating userId={}, uri={}", authentication.getPrincipal(),
+				requestUri);
+		} else if (StringUtils.hasText(jwt)) {
+			log.warn("[JWT AUTH] Invalid Token - uri={}", requestUri);
+		}
+
+		filterChain.doFilter(request, response);
+	}
+
+	// Request Header에서 토큰 정보 추출
+	private String resolveToken(HttpServletRequest request) {
+		String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+		if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
+			return bearerToken.substring(7);
+		}
+		return null;
+	}
+}

--- a/src/main/java/com/threestar/trainus/global/config/security/JwtProvider.java
+++ b/src/main/java/com/threestar/trainus/global/config/security/JwtProvider.java
@@ -1,0 +1,100 @@
+package com.threestar.trainus.global.config.security;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import java.util.List;
+
+import javax.crypto.SecretKey;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Component;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SignatureException;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class JwtProvider {
+
+	private final SecretKey key;
+	private final long accessTokenValidityInMilliseconds;
+	private final long refreshTokenValidityInMilliseconds;
+
+	public JwtProvider(@Value("${jwt.secret}") String secret,
+		@Value("${jwt.access-token-validity}") long accessTokenValidityInMilliseconds,
+		@Value("${jwt.refresh-token-validity}") long refreshTokenValidityInMilliseconds) {
+		this.key = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+		this.accessTokenValidityInMilliseconds = accessTokenValidityInMilliseconds;
+		this.refreshTokenValidityInMilliseconds = refreshTokenValidityInMilliseconds;
+	}
+
+	// 1. Access Token 생성
+	public String createAccessToken(Long userId, String role) {
+		return createToken(userId, role, accessTokenValidityInMilliseconds);
+	}
+
+	// 2. Refresh Token 생성
+	public String createRefreshToken(Long userId, String role) {
+		return createToken(userId, role, refreshTokenValidityInMilliseconds);
+	}
+
+	// 공통 토큰 생성 로직
+	private String createToken(Long userId, String role, long validityInMilliseconds) {
+		Date now = new Date();
+		Date validity = new Date(now.getTime() + validityInMilliseconds);
+
+		return Jwts.builder()
+			.subject(userId.toString())
+			.claim("role", role)
+			.issuedAt(now)
+			.expiration(validity)
+			.signWith(key)
+			.compact();
+	}
+
+	// 3. 토큰에서 인증 정보(Authentication) 추출
+	public Authentication getAuthentication(String token) {
+		Claims claims = parseClaims(token);
+
+		Long userId = Long.valueOf(claims.getSubject());
+		String role = claims.get("role", String.class);
+		List<SimpleGrantedAuthority> authorities = List.of(new SimpleGrantedAuthority("ROLE_" + role));
+
+		return new UsernamePasswordAuthenticationToken(userId, null, authorities);
+	}
+
+	// 4. 토큰 유효성 검증
+	public boolean validateToken(String token) {
+		try {
+			Jwts.parser().verifyWith(key).build().parseSignedClaims(token);
+			return true;
+		} catch (SecurityException | MalformedJwtException | SignatureException e) {
+			log.error("잘못된 JWT 서명입니다: {}", e.getMessage());
+		} catch (ExpiredJwtException e) {
+			log.error("만료된 JWT 토큰입니다: {}", e.getMessage());
+		} catch (UnsupportedJwtException e) {
+			log.error("지원되지 않는 JWT 토큰입니다: {}", e.getMessage());
+		} catch (IllegalArgumentException e) {
+			log.error("JWT 토큰이 잘못되었습니다: {}", e.getMessage());
+		}
+		return false;
+	}
+
+	// 내부 클레임 파싱
+	private Claims parseClaims(String token) {
+		try {
+			return Jwts.parser().verifyWith(key).build().parseSignedClaims(token).getPayload();
+		} catch (ExpiredJwtException e) {
+			return e.getClaims();
+		}
+	}
+}

--- a/src/main/java/com/threestar/trainus/global/config/security/JwtProvider.java
+++ b/src/main/java/com/threestar/trainus/global/config/security/JwtProvider.java
@@ -37,12 +37,12 @@ public class JwtProvider {
 		this.refreshTokenValidityInMilliseconds = refreshTokenValidityInMilliseconds;
 	}
 
-	// 1. Access Token 생성
+	// Access Token 생성
 	public String createAccessToken(Long userId, String role) {
 		return createToken(userId, role, accessTokenValidityInMilliseconds);
 	}
 
-	// 2. Refresh Token 생성
+	// Refresh Token 생성
 	public String createRefreshToken(Long userId, String role) {
 		return createToken(userId, role, refreshTokenValidityInMilliseconds);
 	}
@@ -61,7 +61,7 @@ public class JwtProvider {
 			.compact();
 	}
 
-	// 3. 토큰에서 인증 정보(Authentication) 추출
+	// 토큰에서 Authentication 추출
 	public Authentication getAuthentication(String token) {
 		Claims claims = parseClaims(token);
 
@@ -72,7 +72,7 @@ public class JwtProvider {
 		return new UsernamePasswordAuthenticationToken(userId, null, authorities);
 	}
 
-	// 4. 토큰 유효성 검증
+	// 토큰 유효성 검증
 	public boolean validateToken(String token) {
 		try {
 			Jwts.parser().verifyWith(key).build().parseSignedClaims(token);

--- a/src/main/java/com/threestar/trainus/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/threestar/trainus/global/config/security/SecurityConfig.java
@@ -19,7 +19,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class SecurityConfig {
 
-	private final SessionAuthenticationFilter sessionAuthenticationFilter;
+	private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
 	@Bean
 	public PasswordEncoder passwordEncoder() {
@@ -40,11 +40,11 @@ public class SecurityConfig {
 				.anyRequest()
 				.authenticated()
 			)
-			.addFilterBefore(sessionAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
-			.formLogin(form -> form.disable())        // 폼 로그인 비활성화
-			.httpBasic(basic -> basic.disable())      // HTTP Basic 비활성화
+			.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+			.formLogin(form -> form.disable())
+			.httpBasic(basic -> basic.disable())
 			.sessionManagement(session -> session
-				.sessionCreationPolicy(org.springframework.security.config.http.SessionCreationPolicy.IF_REQUIRED)
+				.sessionCreationPolicy(org.springframework.security.config.http.SessionCreationPolicy.STATELESS)
 			)
 			.csrf(csrf -> csrf.disable())
 			.cors(cors -> cors.configurationSource(corsConfigurationSource()));

--- a/src/main/java/com/threestar/trainus/global/resolver/LoginUserArgumentResolver.java
+++ b/src/main/java/com/threestar/trainus/global/resolver/LoginUserArgumentResolver.java
@@ -1,6 +1,8 @@
 package com.threestar.trainus.global.resolver;
 
 import org.springframework.core.MethodParameter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
@@ -11,9 +13,6 @@ import com.threestar.trainus.global.annotation.LoginUser;
 import com.threestar.trainus.global.exception.domain.ErrorCode;
 import com.threestar.trainus.global.exception.handler.BusinessException;
 
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpSession;
-
 @Component
 public class LoginUserArgumentResolver implements HandlerMethodArgumentResolver {
 
@@ -23,23 +22,21 @@ public class LoginUserArgumentResolver implements HandlerMethodArgumentResolver 
 	}
 
 	@Override
-	public Object resolveArgument(MethodParameter parameter,
-		ModelAndViewContainer mavContainer,
-		NativeWebRequest webRequest,
-		WebDataBinderFactory binderFactory) throws Exception {
+	public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+		NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
 
-		HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
-		HttpSession session = request.getSession(false);
+		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
-		if (session == null) {
+		if (authentication == null || !authentication.isAuthenticated()) {
 			throw new BusinessException(ErrorCode.AUTHENTICATION_REQUIRED);
 		}
 
-		Long userId = (Long)session.getAttribute("LOGIN_USER");
-		if (userId == null) {
-			throw new BusinessException(ErrorCode.AUTHENTICATION_REQUIRED);
+		Object principal = authentication.getPrincipal();
+
+		if (principal instanceof Long) {
+			return (Long)principal;
 		}
 
-		return userId;
+		throw new BusinessException(ErrorCode.AUTHENTICATION_REQUIRED);
 	}
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -61,3 +61,8 @@ logging:
     root: INFO
     org.hibernate.SQL: WARN
     org.springframework.orm.jpa: ERROR
+
+jwt:
+  secret: ${JWT_SECRET}
+  access-token-validity: 3600000 # 1H
+  refresh-token-validity: 604800000 # 7D


### PR DESCRIPTION
## 🚀 작업 개요
* 기존의 HttpSession 기반 인증 구조를 제거하고 JWT Stateless 인증 아키텍처로 전환
* 이번 작업은 10만 건 이상의 고부하 상황에서 인증 과정의 DB/Redis I/O를 제거하여 HikariCP 고갈 및 네트워크 병목 현상을 원천 차단하는 데 목적이 있음

## 🛠️ 작업 내용
* JWT 기반 인증 인프라 구축
* Spring Security 정책 변경
* 환경 변수 적용 완료(JWT 관련 Secret)
* 비즈니스 로직 리팩토링 (Stateless 전환)
   * `UserService`/`UserController`: HttpSession 의존성을 전면 제거하고 로그인 시 JWT 토큰 세트를 반환하도록 수정
   * `LoginUserArgumentResolver`: 세션 대신 `SecurityContextHolder`에서 인증 정보를 추출하도록 변경하여 `@LoginUser` 어노테이션의 무상태 연동 완료
   * DTO/Mapper: `LoginResponseDto`에 토큰 필드를 추가하고 매퍼 로직 업데이트


 
## ✅ PR 유형
- [x] 새로운 기능 추가
- [x] 코드 리팩토링

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?

## 🔗 관련 이슈
- #202 

## 💬 기타 참고 사항
