### PR TITLE
feat: 그라파나 대시보드 코드화 및 단일 서버 모니터링 환경 구축

### DIFF
--- a/docker-compose-monitoring.yml
+++ b/docker-compose-monitoring.yml
@@ -26,6 +26,8 @@ services:
       - "3000:3000"
     volumes:
       - ./grafana-data:/var/lib/grafana
+      - ./prometheus-grafana/grafana/provisioning:/etc/grafana/provisioning
+      - ./prometheus-grafana/grafana/dashboards:/var/lib/grafana/dashboards:ro # 읽기 전용 마운트
     environment:
       - GF_SECURITY_ADMIN_PASSWORD=admin
     networks:

--- a/prometheus-grafana/grafana/dashboards/baseline-dashboard.json
+++ b/prometheus-grafana/grafana/dashboards/baseline-dashboard.json
@@ -1,0 +1,133 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus-default"
+      },
+      "description": "독립 서버(Baseline)의 스레드 점유 상태를 집중 모니터링합니다.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "never"
+          },
+          "mappings": [],
+          "min": 0,
+          "unit": "short"
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "id": 1,
+      "options": {
+        "legend": { "calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "multi" }
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "expr": "tomcat_threads_busy_threads{env=\"baseline\"}",
+          "legendFormat": "Busy Threads",
+          "refId": "A"
+        },
+        {
+          "expr": "tomcat_threads_config_max_threads{env=\"baseline\"}",
+          "legendFormat": "Max Threads",
+          "refId": "B"
+        }
+      ],
+      "title": "[Baseline] Tomcat Thread Status",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus-default"
+      },
+      "description": "DB 커넥션 풀 고갈 여부를 확인합니다. Pending 발생 시 주의가 필요합니다.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "lineWidth": 2, "fillOpacity": 10 },
+          "unit": "short"
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "id": 2,
+      "options": {
+        "legend": { "calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "bottom" }
+      },
+      "targets": [
+        {
+          "expr": "hikaricp_connections_active{env=\"baseline\"}",
+          "legendFormat": "Active Connections",
+          "refId": "A"
+        },
+        {
+          "expr": "hikaricp_connections_pending{env=\"baseline\"}",
+          "legendFormat": "Pending Connections",
+          "refId": "B"
+        }
+      ],
+      "title": "[Baseline] HikariCP Connection Pool",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus-default"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "lineWidth": 2 },
+          "unit": "s"
+        }
+      },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 8 },
+      "id": 3,
+      "targets": [
+        {
+          "expr": "rate(http_server_requests_seconds_sum{env=\"baseline\"}[1m]) / rate(http_server_requests_seconds_count{env=\"baseline\"}[1m])",
+          "legendFormat": "{{uri}}",
+          "refId": "A"
+        }
+      ],
+      "title": "[Baseline] Average Response Time by URI",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 40,
+  "time": { "from": "now-15m", "to": "now" },
+  "title": "TrainUs Baseline Dashboard (Single Node)",
+  "uid": "trainus-baseline-v1",
+  "version": 1
+}

--- a/prometheus-grafana/grafana/dashboards/production-dashboard.json
+++ b/prometheus-grafana/grafana/dashboards/production-dashboard.json
@@ -1,0 +1,338 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus-default"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 9,
+        "x": 0,
+        "y": 0
+      },
+      "id": 119,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus-default"
+          },
+          "editorMode": "code",
+          "expr": "tomcat_threads_busy_threads{role=\"api\"}",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 2,
+          "legendFormat": "TOMCAT - BSY ({{instance}})",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus-default"
+          },
+          "editorMode": "code",
+          "expr": "tomcat_threads_current_threads{role=\"api\"}",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 2,
+          "legendFormat": "TOMCAT - CUR ({{instance}})",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus-default"
+          },
+          "editorMode": "code",
+          "expr": "tomcat_threads_config_max_threads{role=\"api\"}",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 2,
+          "legendFormat": "TOMCAT - MAX ({{instance}})",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Thread Utilisation (API)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus-default"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 10,
+        "x": 9,
+        "y": 0
+      },
+      "id": 36,
+      "options": {
+        "dataLinks": [],
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max",
+            "min"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus-default"
+          },
+          "editorMode": "code",
+          "expr": "hikaricp_connections_active{role=\"api\"}",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Active ({{instance}})",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus-default"
+          },
+          "editorMode": "code",
+          "expr": "hikaricp_connections_idle{role=\"api\"}",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Idle ({{instance}})",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus-default"
+          },
+          "editorMode": "code",
+          "expr": "hikaricp_connections_pending{role=\"api\"}",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Pending ({{instance}})",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "HikariCP Connections (API)",
+      "type": "timeseries"
+    }
+  ],
+  "preload": false,
+  "refresh": "5s",
+  "schemaVersion": 40,
+  "tags": [
+    "production"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "production",
+          "value": "production"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Environment",
+        "multi": false,
+        "name": "env",
+        "options": [
+          {
+            "selected": true,
+            "text": "production",
+            "value": "production"
+          },
+          {
+            "selected": false,
+            "text": "baseline",
+            "value": "baseline"
+          }
+        ],
+        "query": "production,baseline",
+        "queryValue": "",
+        "skipUrlSync": false,
+        "type": "custom"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-15m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "TrainUs Production Dashboard",
+  "uid": "trainus-prod-v1",
+  "version": 1,
+  "weekStart": ""
+}

--- a/prometheus-grafana/grafana/provisioning/dashboards/dashboard.yml
+++ b/prometheus-grafana/grafana/provisioning/dashboards/dashboard.yml
@@ -1,0 +1,14 @@
+apiVersion: 1
+
+providers:
+  - name: 'TrainUs Dashboards'
+    orgId: 1
+    folder: ''
+    type: file
+    disableDeletion: false
+    editable: true
+    updateIntervalSeconds: 10
+    allowUiUpdates: true
+    options:
+      path: /var/lib/grafana/dashboards # JSON 파일들이 실제로 마운트된 경로
+      foldersFromFilesStructure: true

--- a/prometheus-grafana/grafana/provisioning/datasources/datasource.yml
+++ b/prometheus-grafana/grafana/provisioning/datasources/datasource.yml
@@ -1,0 +1,10 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://data-prometheus:9090
+    isDefault: true
+    editable: true
+    uid: prometheus-default # 대시보드 JSON과 일치시키기 위해 UID 고정

--- a/prometheus-grafana/prometheus/config/prometheus.yml
+++ b/prometheus-grafana/prometheus/config/prometheus.yml
@@ -19,6 +19,26 @@ scrape_configs:
         labels:
           env: 'local'
 
+  # 독립 API 서버 수집
+  - job_name: 'trainus-independent-api'
+    metrics_path: '/actuator/prometheus'
+    ec2_sd_configs:
+      - region: ap-northeast-2
+        port: 8082
+    relabel_configs:
+      # 'Name' 태그가 'TrainUs-Independent-Api'로 시작하는 인스턴스
+      - source_labels: [__meta_ec2_tag_Name]
+        regex: TrainUs-Independent-Api.*
+        action: keep
+
+      # 그라파나 대시보드용 라벨 추가
+      - source_labels: [__meta_ec2_instance_id]
+        target_label: instance_id
+      - target_label: env
+        replacement: 'baseline'
+      - target_label: role
+        replacement: 'api'
+
   # API 서버 수집
   - job_name: 'trainus-api-apps'
     metrics_path: '/actuator/prometheus'


### PR DESCRIPTION
## 🛠️ 작업 내용
듀얼 레디스 및 배치 파이프라이닝 최적화 성능을 정밀하게 측정하기 위해 기존 단일 인스턴스 환경의 전용 모니터링 환경을 구축했습니다. 또한 대시보드 유실 방지를 위해 모든 설정을 코드화(JSON)했습니다.

- Dashboard as Code: provisioning 설정을 도입하여 서버 재시작 시에도 대시보드와 데이터소스가 자동으로 복구되도록 구현
- 단일 인스턴스 타겟팅: 프로메테우스의 EC2 Service Discovery 설정을 수정하여 단일 인스턴스를 env: baseline 라벨로 분리 수집
- 전용 대시보드 구축:
  - Production: 전체 서비스 트래픽 및 오토스케일링 그룹 통합 모니터링
  - Baseline: 단일 노드 성능(Thread, Connection Pool, Latency) 집중 분석용
 - 인프라 설정 최적화: 그라파나 컨테이너 내 대시보드 마운트 경로를 정리하고 권한 충돌 문제를 해결

## ✅ PR 유형
- [x] 새로운 기능 추가
- [x] 코드 리팩토링

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?

## 🔗 관련 이슈
- #197 

## 💬 기타 참고 사항
