### PR TITLE
refactor: Row Lock 경합 제거를 위한 레슨 참가자 수 업데이트 로직 디커플링

### DIFF
--- a/src/main/java/com/threestar/trainus/domain/lesson/issue/LessonApplyService.java
+++ b/src/main/java/com/threestar/trainus/domain/lesson/issue/LessonApplyService.java
@@ -85,20 +85,8 @@ public class LessonApplyService {
 		Map<Long, Long> countsByLesson = messages.stream()
 			.collect(Collectors.groupingBy(ApplyMessage::lessonId, Collectors.counting()));
 
-		for (Map.Entry<Long, Long> entry : countsByLesson.entrySet()) {
-			Long lessonId = entry.getKey();
-			int amount = entry.getValue().intValue();
-
-			int affectedRows = lessonRepository.incrementParticipantCountBatch(lessonId, amount,
-				LessonStatus.RECRUITMENT_COMPLETED);
-
-			if (affectedRows == 0) {
-				log.error("Batch update failed for lesson [{}]: Capacity exceeded", lessonId);
-				Metrics.counter("lesson.apply.rejected", "lessonId", String.valueOf(lessonId)).increment(amount);
-				throw new BusinessException(ErrorCode.LESSON_NOT_AVAILABLE);
-			}
-
-			// Dirty Set 등록
+		for (Long lessonId : countsByLesson.keySet()) {
+			// Dirty Set 등록 (스케줄러 보정 요청)
 			coreRedisTemplate.opsForSet().add(LessonApplyStreamConstant.DIRTY_SET_KEY, String.valueOf(lessonId));
 		}
 
@@ -147,10 +135,12 @@ public class LessonApplyService {
 				return false;
 			}
 
-			// 실제 DB 저장 및 카운트 증가 (원자적 연산 적용)
+			// 실제 DB 저장
 			LessonParticipant participant = LessonParticipant.builder().lesson(lesson).user(user).build();
 			lessonParticipantRepository.save(participant);
-			lessonRepository.incrementParticipantCount(lessonId);
+
+			// Dirty Set 등록 (보정 스케줄러 처리 요청)
+			coreRedisTemplate.opsForSet().add(LessonApplyStreamConstant.DIRTY_SET_KEY, String.valueOf(lessonId));
 
 			// 처리 성공 결과 저장 및 지연 시간 측정
 			long latency = System.currentTimeMillis() - produceTime;

--- a/src/main/java/com/threestar/trainus/domain/lesson/issue/LessonStockReconciliationScheduler.java
+++ b/src/main/java/com/threestar/trainus/domain/lesson/issue/LessonStockReconciliationScheduler.java
@@ -2,12 +2,14 @@ package com.threestar.trainus.domain.lesson.issue;
 
 import java.util.Optional;
 
+import com.threestar.trainus.domain.lesson.teacher.repository.LessonParticipantRepository;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Profile;
 import org.springframework.data.redis.connection.stream.StreamInfo;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 
@@ -24,6 +26,7 @@ import lombok.extern.slf4j.Slf4j;
 public class LessonStockReconciliationScheduler {
 
 	private final LessonRepository lessonRepository;
+	private final LessonParticipantRepository lessonParticipantRepository;
 	private final LessonApplyProducer lessonApplyProducer;
 
 	@Qualifier("coreRedisTemplate")
@@ -32,6 +35,7 @@ public class LessonStockReconciliationScheduler {
 	@Qualifier("mqRedisTemplate")
 	private final StringRedisTemplate mqRedisTemplate;
 
+	@Transactional
 	@Scheduled(fixedRate = 30000)
 	@SchedulerLock(name = "LessonStockReconciliation", lockAtMostFor = "25s", lockAtLeastFor = "20s")
 	public void reconcileStock() {
@@ -41,7 +45,7 @@ public class LessonStockReconciliationScheduler {
 			return;
 		}
 
-		log.info("Starting Smart Stock Reconciliation (DB -> Redis)...");
+		log.info("Starting Smart Stock Reconciliation (Actual DB Count -> Lesson Row -> Redis)...");
 
 		String dirtySetKey = LessonApplyStreamConstant.DIRTY_SET_KEY;
 
@@ -57,7 +61,14 @@ public class LessonStockReconciliationScheduler {
 			try {
 				Long lessonId = Long.valueOf(lessonIdStr);
 
-				// DB 카운트 조회
+				// 실제 참여자 수 계산 (DB)
+				long actualParticipantCount = lessonParticipantRepository.countByLessonId(lessonId);
+
+				// Lesson 테이블 카운트 보정 및 상태 변경
+				lessonRepository.updateParticipantCount(lessonId, (int)actualParticipantCount,
+					com.threestar.trainus.domain.lesson.teacher.entity.LessonStatus.RECRUITMENT_COMPLETED);
+
+				// 최신 레슨 정보 조회하여 Redis 동기화
 				Optional<Lesson> lessonOpt = lessonRepository.findById(lessonId);
 				if (lessonOpt.isPresent()) {
 					Lesson lesson = lessonOpt.get();
@@ -74,7 +85,8 @@ public class LessonStockReconciliationScheduler {
 					coreRedisTemplate.opsForSet().remove(dirtySetKey, lessonIdStr);
 
 					processedCount++;
-					log.debug("Reconciled lesson [{}] stock to [{}]", lessonId, currentStock);
+					log.debug("Reconciled lesson [{}] to actual count [{}] and stock [{}]", 
+						lessonId, actualParticipantCount, currentStock);
 				}
 			} catch (Exception e) {
 				log.error("Failed to reconcile lesson [{}]: {}", lessonIdStr, e.getMessage());

--- a/src/main/java/com/threestar/trainus/domain/lesson/teacher/repository/LessonRepository.java
+++ b/src/main/java/com/threestar/trainus/domain/lesson/teacher/repository/LessonRepository.java
@@ -80,6 +80,21 @@ public interface LessonRepository extends JpaRepository<Lesson, Long> {
 		updateDecrementInternal(lessonId, LessonStatus.RECRUITING);
 	}
 
+	@Modifying(clearAutomatically = true)
+	@Query("""
+		UPDATE Lesson l
+		SET l.participantCount = :count,
+		    l.status = CASE WHEN :count >= l.maxParticipants 
+		                    THEN :completedStatus 
+		                    ELSE l.status END
+		WHERE l.id = :lessonId
+		""")
+	int updateParticipantCount(
+		@Param("lessonId") Long lessonId,
+		@Param("count") int count,
+		@Param("completedStatus") LessonStatus completedStatus
+	);
+
 	// 중복 레슨 검증(같은 강사가 같은 이름과 시작시간으로 레슨 생성했는지 체크)
 	@Query("""
 		SELECT COUNT(l) > 0 FROM Lesson l


### PR DESCRIPTION
## 📝 배경 및 문제점
**현상**
현재 컨슈머 로직에서 각 메시지(또는 배치) 처리 시 Lesson 테이블의 `participantCount`를 실시간으로 업데이트함

**원인** 
단일 lessonId에 대한 부하 집중 시 DB의 Row Lock 경합으로 인해 컨슈머를 Scale-out해도 처리량이 선형적으로 증가하지 않는 병목 발생

**지표** 
iostat 확인 결과 디스크 I/O 유틸리티는 낮으나(%util 30% 미만) DB CPU 사용량이 높고 락 대기 시간으로 인해 전체 레이턴시가 증가함

## 🚀 개선 목표
   - 메시지 소비 단계와 Lesson 로우 업데이트 단계를 분리(Decoupling)하여 Row Lock 경합을 원천 차단
   - 최종 일관성(Eventual Consistency) 모델을 도입하여 피크 타임 처리량을 극대화

## 🛠 작업 내용

### 1. 메시지 소비 로직 수정
-  메시지 처리 시에는 `Participant` 엔티티의 `INSERT` 작업만 수행 (Row Lock 경합 없음)
- `Lesson` 엔티티에 대한 직접적인 `UPDATE` 또는 Dirty Checking 호출 제거
### 2. 최종 보정 로직 구현
-  메시지 소비가 완료되었거나 큐가 비어있는 시점에 한 번에 `Lesson.participantCount`를 업데이트
-  `COUNT(*)` 쿼리를 기반으로 한 원자적(Atomic) 업데이트 쿼리 적용
   
## ✅ PR 유형
- [x] 코드 리팩토링

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?

## 🔗 관련 이슈
- #221 

## 💬 기타 참고 사항
