### PR TITLE
fix: 음수 Redis 재고 상태에서 보정 연기

### DIFF
--- a/src/main/java/com/threestar/trainus/domain/lesson/issue/LessonStockReconciliationScheduler.java
+++ b/src/main/java/com/threestar/trainus/domain/lesson/issue/LessonStockReconciliationScheduler.java
@@ -110,6 +110,12 @@ public class LessonStockReconciliationScheduler {
 				// 실제 참여자 수 계산 (DB)
 				long actualParticipantCount = lessonParticipantRepository.countByLessonId(lessonId);
 
+				// Redis 재고가 음수라면 producer의 DECR -> INCR rollback 중으로 판단
+				String redisStockBefore = coreRedisTemplate.opsForValue().get(stockKey);
+				if (isNegativeRedisStock(lessonId, redisStockBefore)) {
+					continue;
+				}
+
 				// Lesson 테이블 카운트 보정 및 상태 변경
 				lessonRepository.updateParticipantCount(lessonId, (int)actualParticipantCount,
 					com.threestar.trainus.domain.lesson.teacher.entity.LessonStatus.RECRUITMENT_COMPLETED);
@@ -125,7 +131,6 @@ public class LessonStockReconciliationScheduler {
 						currentStock = 0;
 
 					Long waitingRoomSize = coreRedisTemplate.opsForZSet().size(waitingRoomKey);
-					String redisStockBefore = coreRedisTemplate.opsForValue().get(stockKey);
 					Long streamSize = mqRedisTemplate.opsForStream().size(LessonApplyStreamConstant.STREAM_KEY);
 					log.info(
 						"Reconciliation diagnostics. lessonId={}, dbCount={}, maxParticipants={}, calculatedStock={}, redisStockBefore={}, waitingRoomSize={}, streamSize={}, busyCount={}, lastActive={}",
@@ -148,6 +153,26 @@ public class LessonStockReconciliationScheduler {
 		}
 
 		log.info("Finished Smart Stock Reconciliation for {} lessons.", processedCount);
+	}
+
+	private boolean isNegativeRedisStock(Long lessonId, String redisStock) {
+		if (redisStock == null) {
+			return false;
+		}
+
+		try {
+			int currentStock = Integer.parseInt(redisStock);
+			if (currentStock < 0) {
+				log.info("Redis stock is negative. lessonId={}, stock={}. Postponing reconciliation.", lessonId,
+					redisStock);
+				return true;
+			}
+			return false;
+		} catch (NumberFormatException e) {
+			log.warn("Failed to parse Redis stock. lessonId={}, stock={}. Postponing reconciliation.", lessonId,
+				redisStock);
+			return true;
+		}
 	}
 
 	// 미처리 메세지 확인 메서드 (Core Redis)


### PR DESCRIPTION
## 🚀 작업 개요
Redis 선착순 필터의 `DECR -> INCR rollback` 구간과 보정 스케줄러의 `setStock()`이 충돌하지 않도록 Redis 재고가 음수인 경우 보정을 연기하도록 수정했습니다.

## 🛠️ 작업 내용

**음수 Redis 재고 보정 차단**
* 보정 직전 `lesson:stock:{lessonId}` 값을 확인
* Redis 재고가 음수라면 producer의 초과 요청 reject rollback이 진행 중인 상태로 보고 해당 레슨 보정을 건너뜀
* Redis 재고 값이 숫자로 파싱되지 않는 경우에도 상태를 신뢰할 수 없으므로 보정을 연기


## ✅ PR 유형
- [x] 버그 수정
- [ ] 성능 개선
- [ ] 새로운 기능 추가
- [x] 코드 리팩토링
- [ ] 파일 혹은 폴더명 수정
- [ ] 문서 수정
- [ ] 설정 변경

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?

## 🔗 관련 이슈
#221 

## 💬 기타 참고 사항
* Producer는 선착순 필터에서 `DECR` 후 음수면 `INCR`로 롤백
* 고부하 상황에서는 Redis stock이 짧게 음수가 될 수 있음
* 이 시점에 보정 스케줄러가 `setStock(0)`을 수행하면, 이후 남은 rollback `INCR`이 stock을 양수로 열어 초과 신청을 허용하는 상황 발생
   