### PR TITLE
fix: 대기열 입장 순서 보존 및 진단 로그 추가

### DIFF
--- a/src/main/java/com/threestar/trainus/domain/lesson/issue/LegacyLessonAdmissionScheduler.java
+++ b/src/main/java/com/threestar/trainus/domain/lesson/issue/LegacyLessonAdmissionScheduler.java
@@ -46,7 +46,7 @@ public class LegacyLessonAdmissionScheduler {
 
 	private void processAdmissionForLesson(Long lessonId) {
 		// 해당 레슨 대기열에서 인원 추출
-		Set<String> requestIds = waitingRoomService.dequeue(lessonId, ADMIT_BATCH_SIZE);
+		List<String> requestIds = waitingRoomService.dequeue(lessonId, ADMIT_BATCH_SIZE);
 
 		if (requestIds.isEmpty()) {
 			return;
@@ -69,7 +69,7 @@ public class LegacyLessonAdmissionScheduler {
 			if (parts.length < 3)
 				continue;
 
-			String requestId = requestIds.toArray(new String[0])[i];
+			String requestId = requestIds.get(i);
 			Long userId = Long.parseLong(parts[2]);
 			Long originalTimestamp = parts.length >= 4 ? Long.parseLong(parts[3]) : System.currentTimeMillis();
 

--- a/src/main/java/com/threestar/trainus/domain/lesson/issue/LessonAdmissionScheduler.java
+++ b/src/main/java/com/threestar/trainus/domain/lesson/issue/LessonAdmissionScheduler.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Profile;
@@ -56,7 +57,7 @@ public class LessonAdmissionScheduler {
 		}
 
 		// 해당 레슨 대기열에서 인원 추출
-		Set<String> requestIds = waitingRoomService.dequeue(lessonId, ADMIT_BATCH_SIZE);
+		List<String> requestIds = waitingRoomService.dequeue(lessonId, ADMIT_BATCH_SIZE);
 
 		if (requestIds.isEmpty()) {
 			return;
@@ -68,7 +69,16 @@ public class LessonAdmissionScheduler {
 			.toList();
 		List<String> statusInfos = mqRedisTemplate.opsForValue().multiGet(statusKeys);
 
-		if (statusInfos == null) return;
+		if (statusInfos == null) {
+			log.warn(
+				"Admission diagnostics. lessonId={}, dequeuedCount={}, statusKeyCount={}, statusInfos=null. Admission skipped after dequeue.",
+				lessonId, requestIds.size(), statusKeys.size());
+			return;
+		}
+
+		AtomicInteger statusNullCount = new AtomicInteger();
+		AtomicInteger invalidStatusCount = new AtomicInteger();
+		AtomicInteger xaddAttemptCount = new AtomicInteger();
 
 		// Pipelining 방식으로 요청 상태 변경 / Stream ADD 로직 일괄 처리
 		mqRedisTemplate.executePipelined(new SessionCallback<Object>() {
@@ -76,14 +86,27 @@ public class LessonAdmissionScheduler {
 			public Object execute(RedisOperations operations) {
 				for (int i = 0; i < statusKeys.size(); i++) {
 					String info = statusInfos.get(i);
-					if (info == null) continue;
+					if (info == null) {
+						statusNullCount.incrementAndGet();
+						continue;
+					}
 
 					String[] parts = info.split(":");
-					if (parts.length < 3) continue;
+					if (parts.length < 3) {
+						invalidStatusCount.incrementAndGet();
+						continue;
+					}
 
-					String requestId = requestIds.toArray(new String[0])[i];
-					Long userId = Long.parseLong(parts[2]);
-					Long originalTimestamp = parts.length >= 4 ? Long.parseLong(parts[3]) : System.currentTimeMillis();
+					String requestId = requestIds.get(i);
+					Long userId;
+					Long originalTimestamp;
+					try {
+						userId = Long.parseLong(parts[2]);
+						originalTimestamp = parts.length >= 4 ? Long.parseLong(parts[3]) : System.currentTimeMillis();
+					} catch (NumberFormatException e) {
+						invalidStatusCount.incrementAndGet();
+						continue;
+					}
 
 					// 상태 변경 (SET)
 					String statusKey = statusKeys.get(i);
@@ -97,11 +120,16 @@ public class LessonAdmissionScheduler {
 					content.put("requestId", requestId);
 					content.put("timestamp", String.valueOf(originalTimestamp));
 					operations.opsForStream().add(LessonApplyStreamConstant.STREAM_KEY, content);
+					xaddAttemptCount.incrementAndGet();
 				}
 				return null;
 			}
 		});
 
+		log.info(
+			"Admission diagnostics. lessonId={}, dequeuedCount={}, statusKeyCount={}, statusNullCount={}, invalidStatusCount={}, xaddAttemptCount={}",
+			lessonId, requestIds.size(), statusKeys.size(), statusNullCount.get(), invalidStatusCount.get(),
+			xaddAttemptCount.get());
 		log.debug("Admitted {} users to MQ via pipeline for lesson: {}", requestIds.size(), lessonId);
 	}
 }

--- a/src/main/java/com/threestar/trainus/domain/lesson/issue/LessonWaitingRoomService.java
+++ b/src/main/java/com/threestar/trainus/domain/lesson/issue/LessonWaitingRoomService.java
@@ -1,6 +1,8 @@
 package com.threestar.trainus.domain.lesson.issue;
 
 import java.time.Duration;
+import java.util.Comparator;
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -51,12 +53,13 @@ public class LessonWaitingRoomService {
 	}
 
 	// 특정 레슨 대기열에서 가장 오래된 N명을 꺼내기
-	public java.util.Set<String> dequeue(Long lessonId, long count) {
+	public List<String> dequeue(Long lessonId, long count) {
 		String waitingRoomKey = String.format(LessonApplyStreamConstant.WAITING_ROOM_KEY, lessonId);
 		return coreRedisTemplate.opsForZSet()
 			.popMin(waitingRoomKey, count)
 			.stream()
+			.sorted(Comparator.comparing(tuple -> tuple.getScore() == null ? Double.MAX_VALUE : tuple.getScore()))
 			.map(tuple -> tuple.getValue())
-			.collect(java.util.stream.Collectors.toSet());
+			.toList();
 	}
 }


### PR DESCRIPTION
## 🚀 작업 개요
대기열 입장 처리 과정에서 선착순 순서를 보존하고 Admission 단계의 요청 유실 여부를 확인하기 위한 진단 로그를 추가했습니다

## 🛠️ 작업 내용
**대기열 순서 보존**
* `dequeue()` 반환 타입을 `Set`에서 `List`로 변경했습니다.
* `popMin()` 결과를 score 기준으로 정렬해 Admission 단계까지 순서를 유지합니다.

**Admission 진단 로그 추가**
* 대기열 pop 수, status 누락/파싱 실패 수, Stream XADD 시도 수를 로깅합니다.
   
## ✅ PR 유형
- [x] 버그 수정
- [ ] 성능 개선
- [ ] 새로운 기능 추가
- [x] 코드 리팩토링
- [ ] 파일 혹은 폴더명 수정
- [ ] 문서 수정
- [ ] 설정 변경

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?

## 🔗 관련 이슈
- #221 

## 💬 기타 참고 사항
