### PR TITLE
fix: Redis Stream 신청 메시지 실패 처리 보강

### DIFF
--- a/src/main/java/com/threestar/trainus/domain/file/controller/S3Controller.java
+++ b/src/main/java/com/threestar/trainus/domain/file/controller/S3Controller.java
@@ -14,6 +14,9 @@ import com.threestar.trainus.domain.file.service.S3Service;
 import com.threestar.trainus.global.annotation.LoginUser;
 import com.threestar.trainus.global.unit.BaseResponse;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "파일 API", description = "S3 Presigned URL 발급 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/s3")

--- a/src/main/java/com/threestar/trainus/domain/lesson/issue/LessonAdmissionScheduler.java
+++ b/src/main/java/com/threestar/trainus/domain/lesson/issue/LessonAdmissionScheduler.java
@@ -73,6 +73,7 @@ public class LessonAdmissionScheduler {
 			log.warn(
 				"Admission diagnostics. lessonId={}, dequeuedCount={}, statusKeyCount={}, statusInfos=null. Admission skipped after dequeue.",
 				lessonId, requestIds.size(), statusKeys.size());
+			requeueAfterAdmissionFailure(lessonId, requestIds, statusKeys, null);
 			return;
 		}
 
@@ -80,56 +81,84 @@ public class LessonAdmissionScheduler {
 		AtomicInteger invalidStatusCount = new AtomicInteger();
 		AtomicInteger xaddAttemptCount = new AtomicInteger();
 
-		// Pipelining 방식으로 요청 상태 변경 / Stream ADD 로직 일괄 처리
-		mqRedisTemplate.executePipelined(new SessionCallback<Object>() {
-			@Override
-			public Object execute(RedisOperations operations) {
-				for (int i = 0; i < statusKeys.size(); i++) {
-					String info = statusInfos.get(i);
-					if (info == null) {
-						statusNullCount.incrementAndGet();
-						continue;
+		try {
+			// Pipelining 방식으로 요청 상태 변경 / Stream ADD 로직 일괄 처리
+			mqRedisTemplate.executePipelined(new SessionCallback<Object>() {
+				@Override
+				public Object execute(RedisOperations operations) {
+					for (int i = 0; i < statusKeys.size(); i++) {
+						String info = statusInfos.get(i);
+						if (info == null) {
+							statusNullCount.incrementAndGet();
+							continue;
+						}
+
+						String[] parts = info.split(":");
+						if (parts.length < 3) {
+							invalidStatusCount.incrementAndGet();
+							continue;
+						}
+
+						String requestId = requestIds.get(i);
+						Long userId;
+						Long originalTimestamp;
+						try {
+							userId = Long.parseLong(parts[2]);
+							originalTimestamp = parts.length >= 4 ? Long.parseLong(parts[3]) : System.currentTimeMillis();
+						} catch (NumberFormatException e) {
+							invalidStatusCount.incrementAndGet();
+							continue;
+						}
+
+						// 상태 변경 (SET)
+						String statusKey = statusKeys.get(i);
+						String processingInfo = String.format("%s:%d:%d:%d", LessonApplyStreamConstant.STATUS_PROCESSING, lessonId, userId, originalTimestamp);
+						operations.opsForValue().set(statusKey, processingInfo, java.time.Duration.ofMinutes(LessonApplyStreamConstant.STATUS_TTL_MINUTE));
+
+						// 스트림 추가 (XADD)
+						Map<String, String> content = new HashMap<>();
+						content.put("lessonId", String.valueOf(lessonId));
+						content.put("userId", String.valueOf(userId));
+						content.put("requestId", requestId);
+						content.put("timestamp", String.valueOf(originalTimestamp));
+						operations.opsForStream().add(LessonApplyStreamConstant.STREAM_KEY, content);
+						xaddAttemptCount.incrementAndGet();
 					}
-
-					String[] parts = info.split(":");
-					if (parts.length < 3) {
-						invalidStatusCount.incrementAndGet();
-						continue;
-					}
-
-					String requestId = requestIds.get(i);
-					Long userId;
-					Long originalTimestamp;
-					try {
-						userId = Long.parseLong(parts[2]);
-						originalTimestamp = parts.length >= 4 ? Long.parseLong(parts[3]) : System.currentTimeMillis();
-					} catch (NumberFormatException e) {
-						invalidStatusCount.incrementAndGet();
-						continue;
-					}
-
-					// 상태 변경 (SET)
-					String statusKey = statusKeys.get(i);
-					String processingInfo = String.format("%s:%d:%d:%d", LessonApplyStreamConstant.STATUS_PROCESSING, lessonId, userId, originalTimestamp);
-					operations.opsForValue().set(statusKey, processingInfo, java.time.Duration.ofMinutes(LessonApplyStreamConstant.STATUS_TTL_MINUTE));
-
-					// 스트림 추가 (XADD)
-					Map<String, String> content = new HashMap<>();
-					content.put("lessonId", String.valueOf(lessonId));
-					content.put("userId", String.valueOf(userId));
-					content.put("requestId", requestId);
-					content.put("timestamp", String.valueOf(originalTimestamp));
-					operations.opsForStream().add(LessonApplyStreamConstant.STREAM_KEY, content);
-					xaddAttemptCount.incrementAndGet();
+					return null;
 				}
-				return null;
-			}
-		});
+			});
+		} catch (RuntimeException e) {
+			requeueAfterAdmissionFailure(lessonId, requestIds, statusKeys, statusInfos);
+			log.error("Admission pipeline failed. Requeued requests for lessonId={}", lessonId, e);
+			return;
+		}
 
 		log.info(
 			"Admission diagnostics. lessonId={}, dequeuedCount={}, statusKeyCount={}, statusNullCount={}, invalidStatusCount={}, xaddAttemptCount={}",
 			lessonId, requestIds.size(), statusKeys.size(), statusNullCount.get(), invalidStatusCount.get(),
 			xaddAttemptCount.get());
 		log.debug("Admitted {} users to MQ via pipeline for lesson: {}", requestIds.size(), lessonId);
+	}
+
+	private void requeueAfterAdmissionFailure(
+		Long lessonId,
+		List<String> requestIds,
+		List<String> statusKeys,
+		List<String> statusInfos
+	) {
+		int requeueCount = 0;
+		for (int i = 0; i < requestIds.size(); i++) {
+			String requestId = requestIds.get(i);
+			String statusInfo = statusInfos == null ? null : statusInfos.get(i);
+
+			waitingRoomService.requeueAfterAdmissionFailure(lessonId, requestId);
+			if (statusInfo != null) {
+				mqRedisTemplate.opsForValue()
+					.set(statusKeys.get(i), statusInfo, java.time.Duration.ofMinutes(LessonApplyStreamConstant.STATUS_TTL_MINUTE));
+			}
+			requeueCount++;
+		}
+
+		log.warn("Admission failed after dequeue. Requeued {} requests. lessonId={}", requeueCount, lessonId);
 	}
 }

--- a/src/main/java/com/threestar/trainus/domain/lesson/issue/LessonApplyConsumer.java
+++ b/src/main/java/com/threestar/trainus/domain/lesson/issue/LessonApplyConsumer.java
@@ -34,6 +34,7 @@ public class LessonApplyConsumer implements StreamListener<String, MapRecord<Str
 
 	private final ConcurrentLinkedQueue<MapRecord<String, String, String>> buffer = new ConcurrentLinkedQueue<>();
 	private static final int BATCH_SIZE = 1000;
+	private static final int CHUNK_SIZE = 100;
 	private static final String STREAM_KEY = LessonApplyStreamConstant.STREAM_KEY;
 	private static final String GROUP = LessonApplyStreamConstant.GROUP;
 	private long lastProcessedTime = System.currentTimeMillis();
@@ -99,39 +100,23 @@ public class LessonApplyConsumer implements StreamListener<String, MapRecord<Str
 				value.get("requestId"), Long.parseLong(value.get("timestamp")));
 		}).collect(Collectors.toList());
 
+		processBatch(records, messages);
+	}
+
+	private void processBatch(
+		List<MapRecord<String, String, String>> records,
+		List<ApplyMessage> messages
+	) {
 		try {
 			// DB 배치 처리
 			lessonApplyService.applyBatch(messages);
 
-			// Pipelining 으로 상태 ACK 업데이트 / 스트림에서 DELETE 일괄 처리
-			RecordId[] ids = records.stream().map(MapRecord::getId).toArray(RecordId[]::new);
-			mqRedisTemplate.executePipelined(new org.springframework.data.redis.core.SessionCallback<Object>() {
-				@Override
-				public Object execute(org.springframework.data.redis.core.RedisOperations operations) {
-					operations.opsForStream().acknowledge(STREAM_KEY, GROUP, ids);
-					operations.opsForStream().delete(STREAM_KEY, ids);
-					return null;
-				}
-			});
+			ackAndDeleteAll(records);
 			log.info("Batch processed {} messages successfully", messages.size());
 		} catch (Exception e) {
-			// 실패 시 개별 메세지 실행
-			log.error("Batch failed: {}. Falling back to individual processing.", e.getMessage());
-
-			for (int i = 0; i < records.size(); i++) {
-				MapRecord<String, String, String> record = records.get(i);
-				ApplyMessage msg = messages.get(i);
-
-				try {
-					lessonApplyService.apply(msg.lessonId(), msg.userId(), msg.requestId(), msg.timestamp());
-					mqRedisTemplate.opsForStream().acknowledge(STREAM_KEY, GROUP, record.getId());
-					mqRedisTemplate.opsForStream().delete(STREAM_KEY, record.getId());
-				} catch (Exception ex) {
-					log.error("Individual message failed: {}, Error={}", msg.requestId(), ex.getMessage());
-					mqRedisTemplate.opsForStream().acknowledge(STREAM_KEY, GROUP, record.getId());
-					mqRedisTemplate.opsForStream().delete(STREAM_KEY, record.getId());
-				}
-			}
+			// 배치 실패 시 chunk 단위 재시도
+			log.error("Batch failed: {}. Retrying by chunks.", e.getMessage());
+			processChunks(records, messages);
 		} finally {
 			// 작업 완료 후 각 레슨별로 이번 배치에서 처리한 개수만큼 Busy 카운터 감소, 마지막 처리 시점 기록
 			Map<Long, Long> countsPerLesson = messages.stream()
@@ -146,9 +131,71 @@ public class LessonApplyConsumer implements StreamListener<String, MapRecord<Str
 		}
 	}
 
+	private void processChunks(
+		List<MapRecord<String, String, String>> records,
+		List<ApplyMessage> messages
+	) {
+		for (int from = 0; from < messages.size(); from += CHUNK_SIZE) {
+			// 전체 메세지 chunk로 나누어 처리
+			int to = Math.min(from + CHUNK_SIZE, messages.size());
+			List<MapRecord<String, String, String>> chunkRecords = records.subList(from, to);
+			List<ApplyMessage> chunkMessages = messages.subList(from, to);
+
+			try {
+				lessonApplyService.applyBatch(chunkMessages);
+				ackAndDeleteAll(chunkRecords);
+				log.info("Chunk processed {} messages successfully", chunkMessages.size());
+			} catch (Exception e) {
+				// chunk 단위에서도 실패한 경우에만 개별 메세지 처리로 전환
+				log.error("Chunk failed: {}. Falling back to individual processing.", e.getMessage());
+				processIndividually(chunkRecords, chunkMessages);
+			}
+		}
+	}
+
+	private void processIndividually(
+		List<MapRecord<String, String, String>> records,
+		List<ApplyMessage> messages
+	) {
+		for (int i = 0; i < records.size(); i++) {
+			MapRecord<String, String, String> record = records.get(i);
+			ApplyMessage msg = messages.get(i);
+
+			try {
+				boolean completed = lessonApplyService.apply(msg.lessonId(), msg.userId(), msg.requestId(), msg.timestamp());
+				ackAndDelete(record);
+				if (!completed) {
+					// 비즈니스 실패
+					log.warn("Individual message completed as business failure. requestId={}", msg.requestId());
+				}
+			} catch (Exception e) {
+				// 시스템 실패 가능성 : pending 상태 유지
+				log.error("Individual message failed. requestId={}, message remains pending", msg.requestId(), e);
+			}
+		}
+	}
+
 	public void clearBuffer() {
 		buffer.clear();
 		lastProcessedTime = System.currentTimeMillis();
 		log.info("Consumer buffer cleared.");
+	}
+
+	private void ackAndDeleteAll(List<MapRecord<String, String, String>> records) {
+		// Pipelining 으로 여러 메세지를 ACK 처리 후 Stream에서 일괄 삭제
+		RecordId[] ids = records.stream().map(MapRecord::getId).toArray(RecordId[]::new);
+		mqRedisTemplate.executePipelined(new org.springframework.data.redis.core.SessionCallback<Object>() {
+			@Override
+			public Object execute(org.springframework.data.redis.core.RedisOperations operations) {
+				operations.opsForStream().acknowledge(STREAM_KEY, GROUP, ids);
+				operations.opsForStream().delete(STREAM_KEY, ids);
+				return null;
+			}
+		});
+	}
+
+	private void ackAndDelete(MapRecord<String, String, String> record) {
+		mqRedisTemplate.opsForStream().acknowledge(STREAM_KEY, GROUP, record.getId());
+		mqRedisTemplate.opsForStream().delete(STREAM_KEY, record.getId());
 	}
 }

--- a/src/main/java/com/threestar/trainus/domain/lesson/issue/LessonApplyService.java
+++ b/src/main/java/com/threestar/trainus/domain/lesson/issue/LessonApplyService.java
@@ -61,7 +61,11 @@ public class LessonApplyService {
 			.stream()
 			.collect(Collectors.toMap(Lesson::getId, l -> l));
 
-		String sql = "INSERT INTO lesson_participants (lesson_id, user_id, join_at, status) VALUES (?, ?, NOW(), ?)";
+		String sql = """
+			INSERT INTO lesson_participants (lesson_id, user_id, join_at, status)
+			VALUES (?, ?, NOW(), ?)
+			ON CONFLICT (user_id, lesson_id) DO NOTHING
+			""";
 		jdbcTemplate.batchUpdate(sql, new BatchPreparedStatementSetter() {
 			@Override
 			public void setValues(PreparedStatement ps, int i) throws SQLException {
@@ -152,10 +156,13 @@ public class LessonApplyService {
 			updateStatus(statusKey, "SUCCESS");
 
 			return true;
-		} catch (Exception e) {
-			log.error("Failed to apply lesson in consumer: {}", e.getMessage());
-			updateStatus(statusKey, "FAIL:ERROR");
+		} catch (BusinessException e) {
+			log.warn("Lesson apply business failed. requestId={}, errorCode={}", requestId, e.getErrorCode());
+			updateStatus(statusKey, "FAIL:" + e.getErrorCode().name());
 			return false;
+		} catch (Exception e) {
+			log.error("Failed to apply lesson in consumer. requestId={}", requestId, e);
+			throw e;
 		}
 	}
 

--- a/src/main/java/com/threestar/trainus/domain/lesson/issue/LessonPendingMessageRecoveryScheduler.java
+++ b/src/main/java/com/threestar/trainus/domain/lesson/issue/LessonPendingMessageRecoveryScheduler.java
@@ -1,0 +1,82 @@
+package com.threestar.trainus.domain.lesson.issue;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.domain.Range;
+import org.springframework.data.redis.connection.stream.MapRecord;
+import org.springframework.data.redis.connection.stream.PendingMessage;
+import org.springframework.data.redis.connection.stream.PendingMessages;
+import org.springframework.data.redis.connection.stream.RecordId;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Profile("consumer")
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class LessonPendingMessageRecoveryScheduler {
+
+	private static final String STREAM_KEY = LessonApplyStreamConstant.STREAM_KEY;
+	private static final String GROUP = LessonApplyStreamConstant.GROUP;
+	private static final String RECOVERY_CONSUMER = "lesson-recovery-consumer";
+	private static final Duration MIN_IDLE_TIME = Duration.ofSeconds(10);
+	private static final int RECOVERY_BATCH_SIZE = 100;
+
+	@Qualifier("mqRedisTemplate")
+	private final StringRedisTemplate mqRedisTemplate;
+
+	private final LessonApplyConsumer lessonApplyConsumer;
+
+	@Scheduled(fixedDelay = 5000)
+	@SchedulerLock(name = "LessonPendingMessageRecovery", lockAtMostFor = "4s", lockAtLeastFor = "1s")
+	public void recoverPendingMessages() {
+		// Pending 메시지 목록 조회
+		PendingMessages pendingMessages = mqRedisTemplate.opsForStream()
+			.pending(STREAM_KEY, GROUP, Range.unbounded(), RECOVERY_BATCH_SIZE);
+
+		if (pendingMessages == null || pendingMessages.isEmpty()) {
+			return;
+		}
+
+		// 일정 시간 이상 응답이 없던 메시지만 선별
+		RecordId[] staleRecordIds = pendingMessages.stream()
+			.filter(message -> message.getElapsedTimeSinceLastDelivery().compareTo(MIN_IDLE_TIME) >= 0)
+			.map(PendingMessage::getId)
+			.toArray(RecordId[]::new);
+
+		if (staleRecordIds.length == 0) {
+			return;
+		}
+
+		List<MapRecord<String, Object, Object>> claimedRecords = mqRedisTemplate.opsForStream()
+			.claim(STREAM_KEY, GROUP, RECOVERY_CONSUMER, MIN_IDLE_TIME, staleRecordIds);
+
+		if (claimedRecords == null || claimedRecords.isEmpty()) {
+			return;
+		}
+
+		// 회수한 메시지를 기존 Consumer 흐름으로 재전달
+		claimedRecords.stream()
+			.map(this::toStringRecord)
+			.forEach(lessonApplyConsumer::onMessage);
+		log.warn("Recovered {} pending lesson apply messages.", claimedRecords.size());
+	}
+
+	private MapRecord<String, String, String> toStringRecord(MapRecord<String, Object, Object> record) {
+		// Claim 결과를 String 기반 Record로 변환
+		Map<String, String> value = new HashMap<>();
+		record.getValue().forEach((key, val) -> value.put(String.valueOf(key), String.valueOf(val)));
+		return MapRecord.create(STREAM_KEY, value).withId(record.getId());
+	}
+}

--- a/src/main/java/com/threestar/trainus/domain/lesson/issue/LessonWaitingRoomService.java
+++ b/src/main/java/com/threestar/trainus/domain/lesson/issue/LessonWaitingRoomService.java
@@ -62,4 +62,11 @@ public class LessonWaitingRoomService {
 			.map(tuple -> tuple.getValue())
 			.toList();
 	}
+
+	// Admission 실패 시 이미 선점된 요청을 유실하지 않도록 대기열에 재등록
+	public void requeueAfterAdmissionFailure(Long lessonId, String requestId) {
+		String waitingRoomKey = String.format(LessonApplyStreamConstant.WAITING_ROOM_KEY, lessonId);
+		coreRedisTemplate.opsForZSet().add(waitingRoomKey, requestId, System.currentTimeMillis());
+		coreRedisTemplate.opsForSet().add(LessonApplyStreamConstant.DIRTY_SET_KEY, String.valueOf(lessonId));
+	}
 }

--- a/src/main/java/com/threestar/trainus/domain/lesson/student/controller/StudentLessonController.java
+++ b/src/main/java/com/threestar/trainus/domain/lesson/student/controller/StudentLessonController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.threestar.trainus.domain.lesson.student.dto.LessonApplicationResponseDto;
+import com.threestar.trainus.domain.lesson.student.dto.LessonApplyRequestResponseDto;
 import com.threestar.trainus.domain.lesson.student.dto.LessonDetailResponseDto;
 import com.threestar.trainus.domain.lesson.student.dto.LessonSearchListResponseDto;
 import com.threestar.trainus.domain.lesson.student.dto.LessonSearchListWrapperDto;
@@ -19,7 +19,6 @@ import com.threestar.trainus.domain.lesson.student.dto.LessonSimpleResponseDto;
 import com.threestar.trainus.domain.lesson.student.dto.MyLessonApplicationListResponseDto;
 import com.threestar.trainus.domain.lesson.student.dto.MyLessonApplicationListWrapperDto;
 import com.threestar.trainus.domain.lesson.student.entity.LessonSortType;
-import com.threestar.trainus.domain.lesson.student.service.StudentLessonFacade;
 import com.threestar.trainus.domain.lesson.student.service.StudentLessonService;
 import com.threestar.trainus.domain.lesson.teacher.entity.Category;
 import com.threestar.trainus.global.annotation.LoginUser;
@@ -43,7 +42,6 @@ import com.threestar.trainus.domain.lesson.student.dto.LessonApplyStatusResponse
 public class StudentLessonController {
 
 	private final StudentLessonService studentLessonService;
-	private final StudentLessonFacade studentLessonFacade;
 
 	// 비동기 선착순 신청 결과 폴링
 	@GetMapping("/apply/status/{requestId}")
@@ -105,15 +103,24 @@ public class StudentLessonController {
 		return BaseResponse.ok("레슨 상세 조회 완료", response, HttpStatus.OK);
 	}
 
-	@PostMapping("/{lessonId}/application")
-	@Operation(summary = "레슨 신청", description = "레슨 ID에 해당되는 레슨을 신청합니다.")
-	public ResponseEntity<BaseResponse<LessonApplicationResponseDto>> createLessonApplication(
+	@PostMapping("/{lessonId}/applications/approval")
+	@Operation(summary = "수락제 레슨 신청", description = "관리자 승인이 필요한 수락제 레슨을 신청합니다.")
+	public ResponseEntity<BaseResponse<LessonApplyRequestResponseDto>> createApprovalLessonApplication(
 		@PathVariable Long lessonId,
 		@LoginUser Long userId
 	) {
-		// 잔여 좌석 확인 메서드
-		LessonApplicationResponseDto response = studentLessonFacade.applyToLessonWithDistributedLock(lessonId, userId);
-		return BaseResponse.ok("레슨 신청 완료", response, HttpStatus.OK);
+		LessonApplyRequestResponseDto response = studentLessonService.applyToApprovalLesson(lessonId, userId);
+		return BaseResponse.ok("레슨 신청 완료", response, HttpStatus.CREATED);
+	}
+
+	@PostMapping("/{lessonId}/applications/open-run")
+	@Operation(summary = "선착순 레슨 신청", description = "선착순 레슨을 Redis Stream 기반 비동기 경로로 신청합니다.")
+	public ResponseEntity<BaseResponse<LessonApplyRequestResponseDto>> createOpenRunLessonApplication(
+		@PathVariable Long lessonId,
+		@LoginUser Long userId
+	) {
+		LessonApplyRequestResponseDto response = studentLessonService.applyToOpenRunLesson(lessonId, userId);
+		return BaseResponse.ok("선착순 레슨 신청 접수 완료", response, HttpStatus.ACCEPTED);
 	}
 
 	@DeleteMapping("/{lessonId}/application")

--- a/src/main/java/com/threestar/trainus/domain/lesson/student/dto/LessonApplyRequestResponseDto.java
+++ b/src/main/java/com/threestar/trainus/domain/lesson/student/dto/LessonApplyRequestResponseDto.java
@@ -1,0 +1,15 @@
+package com.threestar.trainus.domain.lesson.student.dto;
+
+import java.time.LocalDateTime;
+
+import lombok.Builder;
+
+@Builder
+public record LessonApplyRequestResponseDto(
+	Long lessonId,
+	Long userId,
+	String requestId,
+	String status,
+	LocalDateTime appliedAt
+) {
+}

--- a/src/main/java/com/threestar/trainus/domain/lesson/student/service/StudentLessonFacade.java
+++ b/src/main/java/com/threestar/trainus/domain/lesson/student/service/StudentLessonFacade.java
@@ -13,6 +13,7 @@ public class StudentLessonFacade {
 
 	private final StudentLessonService studentLessonService;
 
+	// Benchmark: Redis Stream 방식과 처리량을 비교하기 위한 분산락 기반 Facade
 	@DistributedLock(key = "'lesson_apply:' + #lessonId")
 	public LessonApplicationResponseDto applyToLessonWithDistributedLock(Long lessonId, Long userId) {
 		return studentLessonService.applyToLessonWithDistributedLock(lessonId, userId);

--- a/src/main/java/com/threestar/trainus/domain/lesson/student/service/StudentLessonService.java
+++ b/src/main/java/com/threestar/trainus/domain/lesson/student/service/StudentLessonService.java
@@ -15,11 +15,13 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import com.threestar.trainus.domain.lesson.student.dto.LessonApplicationResponseDto;
+import com.threestar.trainus.domain.lesson.student.dto.LessonApplyRequestResponseDto;
 import com.threestar.trainus.domain.lesson.student.dto.LessonApplyStatusResponseDto;
 import com.threestar.trainus.domain.lesson.student.dto.LessonDetailResponseDto;
 import com.threestar.trainus.domain.lesson.student.dto.LessonSearchListResponseDto;
 import com.threestar.trainus.domain.lesson.student.dto.LessonSearchResponseDto;
 import com.threestar.trainus.domain.lesson.student.dto.LessonSimpleResponseDto;
+import com.threestar.trainus.domain.lesson.issue.LessonApplyProducer;
 import com.threestar.trainus.domain.lesson.issue.LessonApplyStreamConstant;
 import com.threestar.trainus.domain.lesson.student.dto.MyLessonApplicationListResponseDto;
 import com.threestar.trainus.domain.lesson.student.entity.LessonSortType;
@@ -67,6 +69,7 @@ public class StudentLessonService {
 	private final LessonParticipantRepository lessonParticipantRepository;
 	private final LessonApplicationRepository lessonApplicationRepository;
 	private final GeometryFactory geometryFactory;
+	private final LessonApplyProducer lessonApplyProducer;
 
 	@Qualifier("coreRedisTemplate")
 	private final StringRedisTemplate coreRedisTemplate;
@@ -227,6 +230,69 @@ public class StudentLessonService {
 	}
 
 	@Transactional
+	public LessonApplyRequestResponseDto applyToApprovalLesson(Long lessonId, Long userId) {
+		// 레슨 조회
+		Lesson lesson = adminLessonService.findLessonById(lessonId);
+
+		// 유저 조회
+		User user = userService.getUserById(userId);
+
+		// 개설자 신청 불가 체크
+		if (lesson.getLessonLeader().equals(userId)) {
+			throw new BusinessException(ErrorCode.LESSON_CREATOR_CANNOT_APPLY);
+		}
+
+		// 중복 체크
+		boolean alreadyParticipated = lessonParticipantRepository.existsByLessonIdAndUserId(lessonId, userId);
+		boolean alreadyApplied = lessonApplicationRepository.existsByLessonIdAndUserId(lessonId, userId);
+		if (alreadyParticipated || alreadyApplied) {
+			throw new BusinessException(ErrorCode.ALREADY_APPLIED);
+		}
+
+		// 레슨 상태 체크
+		if (lesson.getStatus() != LessonStatus.RECRUITING) {
+			throw new BusinessException(ErrorCode.LESSON_NOT_AVAILABLE);
+		}
+
+		// 선착순 레슨은 수락제 신청 경로에서 제외
+		if (lesson.getOpenRun()) {
+			throw new BusinessException(ErrorCode.LESSON_NOT_AVAILABLE);
+		}
+
+		// 수락제 레슨은 신청만 등록
+		LessonApplication application = LessonApplication.builder()
+			.lesson(lesson)
+			.user(user)
+			.build();
+		lessonApplicationRepository.save(application);
+
+		return LessonApplyRequestResponseDto.builder()
+			.lessonId(lesson.getId())
+			.userId(user.getId())
+			.status(ApplicationStatus.PENDING.name())
+			.appliedAt(application.getCreatedAt())
+			.build();
+	}
+
+	public LessonApplyRequestResponseDto applyToOpenRunLesson(Long lessonId, Long userId) {
+		String requestId = lessonApplyProducer.send(lessonId, userId);
+		if ("ALREADY_APPLIED".equals(requestId)) {
+			throw new BusinessException(ErrorCode.ALREADY_APPLIED);
+		}
+		if (requestId == null) {
+			throw new BusinessException(ErrorCode.LESSON_NOT_AVAILABLE);
+		}
+
+		return LessonApplyRequestResponseDto.builder()
+			.lessonId(lessonId)
+			.userId(userId)
+			.requestId(requestId)
+			.status(LessonApplyStreamConstant.STATUS_WAITING)
+			.build();
+	}
+
+	// Benchmark: 락 미적용 상태의 동시성 문제 재현을 위한 비교용 메서드
+	@Transactional
 	public LessonApplicationResponseDto applyToLessonWithoutLock(Long lessonId, Long userId) {
 		// 레슨 조회
 		Lesson lesson = adminLessonService.findLessonById(lessonId);
@@ -288,6 +354,7 @@ public class StudentLessonService {
 		}
 	}
 
+	// Benchmark: Redis Stream 방식과 처리량을 비교하기 위한 분산락 기반 신청 메서드
 	@Transactional
 	public LessonApplicationResponseDto applyToLessonWithDistributedLock(Long lessonId, Long userId) {
 		// 레슨 조회
@@ -354,6 +421,7 @@ public class StudentLessonService {
 		}
 	}
 
+	// Benchmark: Redis Stream 방식과 처리량을 비교하기 위한 비관적 락 기반 신청 메서드
 	@Transactional
 	public LessonApplicationResponseDto applyToLessonWithPessimisticLock(Long lessonId, Long userId) {
 		// 레슨 조회 (비관적 락)
@@ -421,7 +489,7 @@ public class StudentLessonService {
 		}
 	}
 
-	// facade 패턴 적용 이전 분산락 메서드 (병목 재현)
+	// Benchmark: Facade 분리 이전의 분산락 적용 범위 비교를 위한 메서드
 	@Transactional
 	@DistributedLock(key = "'lesson_apply:' + #lessonId")
 	public LessonApplicationResponseDto applyToLessonWithCoupledLock(Long lessonId, Long userId) {

--- a/src/main/java/com/threestar/trainus/domain/lesson/teacher/controller/LocationCsvController.java
+++ b/src/main/java/com/threestar/trainus/domain/lesson/teacher/controller/LocationCsvController.java
@@ -11,8 +11,10 @@ import org.springframework.web.multipart.MultipartFile;
 import com.threestar.trainus.domain.lesson.teacher.service.LocationCsvService;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
+@Tag(name = "지역 API", description = "법정동 데이터 업로드 및 검증 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/location")

--- a/src/main/java/com/threestar/trainus/domain/lesson/teacher/entity/LessonApplication.java
+++ b/src/main/java/com/threestar/trainus/domain/lesson/teacher/entity/LessonApplication.java
@@ -14,6 +14,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -21,7 +22,12 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@Table(name = "lesson_applications")
+@Table(
+	name = "lesson_applications",
+	uniqueConstraints = {
+		@UniqueConstraint(name = "uq_lesson_applications", columnNames = {"user_id", "lesson_id"})
+	}
+)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class LessonApplication extends BaseDateEntity {
 

--- a/src/main/java/com/threestar/trainus/domain/lesson/teacher/entity/LessonParticipant.java
+++ b/src/main/java/com/threestar/trainus/domain/lesson/teacher/entity/LessonParticipant.java
@@ -16,6 +16,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -23,7 +24,12 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@Table(name = "lesson_participants")
+@Table(
+	name = "lesson_participants",
+	uniqueConstraints = {
+		@UniqueConstraint(name = "uq_lesson_participants", columnNames = {"user_id", "lesson_id"})
+	}
+)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class LessonParticipant {
 	@Id

--- a/src/main/java/com/threestar/trainus/domain/test/controller/TestConcurrencyController.java
+++ b/src/main/java/com/threestar/trainus/domain/test/controller/TestConcurrencyController.java
@@ -27,7 +27,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
-@Tag(name = "동시성 테스트 API", description = "선착순 기능 테스트를 위한 API")
+@Tag(name = "테스트 - 동시성 API", description = "선착순 기능 테스트를 위한 API")
 @Profile({"local", "test"})
 @RestController
 @RequestMapping("/test")

--- a/src/main/java/com/threestar/trainus/global/config/SwaggerConfig.java
+++ b/src/main/java/com/threestar/trainus/global/config/SwaggerConfig.java
@@ -1,13 +1,21 @@
 package com.threestar.trainus.global.config;
 
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springdoc.core.customizers.OpenApiCustomizer;
 
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.tags.Tag;
 
 @Configuration
 public class SwaggerConfig {
@@ -22,7 +30,8 @@ public class SwaggerConfig {
 					.bearerFormat("JWT")
 				)
 			)
-			.info(apiInfo());
+			.info(apiInfo())
+			.tags(apiTags());
 	}
 
 	private Info apiInfo() {
@@ -30,5 +39,42 @@ public class SwaggerConfig {
 			.title("TrainUs API 문서") // API의 제목
 			.description("운동 메이트 매칭 플랫폼의 API 명세서") // API에 대한 설명
 			.version("1.0.0"); // API의 버전
+	}
+
+	@Bean
+	public OpenApiCustomizer tagOrderCustomizer() {
+		return openApi -> {
+			if (openApi.getTags() == null) {
+				return;
+			}
+
+			Map<String, Integer> tagOrder = IntStream.range(0, apiTags().size())
+				.boxed()
+				.collect(Collectors.toMap(i -> apiTags().get(i).getName(), i -> i));
+
+			openApi.setTags(openApi.getTags().stream()
+				.sorted(Comparator.comparingInt(tag -> tagOrder.getOrDefault(tag.getName(), Integer.MAX_VALUE)))
+				.toList());
+		};
+	}
+
+	private List<Tag> apiTags() {
+		return List.of(
+			new Tag().name("유저 API"),
+			new Tag().name("수강생 레슨 API"),
+			new Tag().name("강사용 레슨 API"),
+			new Tag().name("댓글 API"),
+			new Tag().name("리뷰 API"),
+			new Tag().name("쿠폰 API"),
+			new Tag().name("관리자 쿠폰 API"),
+			new Tag().name("결제 API"),
+			new Tag().name("랭킹 조회 API"),
+			new Tag().name("유저 프로필 API"),
+			new Tag().name("지역 API"),
+			new Tag().name("시스템 API"),
+			new Tag().name("파일 API"),
+			new Tag().name("테스트 - S3 API"),
+			new Tag().name("테스트 - 동시성 API")
+		);
 	}
 }

--- a/src/main/java/com/threestar/trainus/global/controller/HealthCheckController.java
+++ b/src/main/java/com/threestar/trainus/global/controller/HealthCheckController.java
@@ -4,6 +4,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "시스템 API", description = "서비스 상태 확인 API")
 @RestController
 public class HealthCheckController {
 

--- a/src/main/java/com/threestar/trainus/global/controller/S3TestController.java
+++ b/src/main/java/com/threestar/trainus/global/controller/S3TestController.java
@@ -15,7 +15,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
-@Tag(name = "S3 테스트 컨트롤러", description = "S3 업로더 테스트용 컨트롤러입니다.")
+@Tag(name = "테스트 - S3 API", description = "S3 업로더 테스트용 컨트롤러입니다.")
 @Profile({"local", "test"})
 @RestController
 @RequestMapping("/api/v1/test/s3")

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -78,6 +78,10 @@ jwt:
   access-token-validity: 3600000 # 1H
   refresh-token-validity: 604800000 # 7D
 
+springdoc:
+  swagger-ui:
+    tags-sorter: none
+
 server:
   tomcat:
     mbeanregistry:


### PR DESCRIPTION
## 🚀 작업 개요
- Redis Stream 기반 선착순 레슨 신청 파이프라인의 실패 처리 안정성을 보강하고 수락제/선착순 신청 경로를 분리했습니다.

## 🛠️ 작업 내용
- 수락제 레슨 신청 API와 선착순 레슨 신청 API를 분리했습니다.
- 선착순 신청은 Redis Stream 기반 비동기 처리 경로를 사용하도록 정리했습니다.
- Consumer 배치 처리 실패 시 chunk 단위 재시도 후 개별 처리로 fallback 하도록 개선했습니다.
- 시스템 예외 발생 시 메시지를 ACK/XDEL하지 않고 pending 상태로 남겨 재처리 가능하도록 변경했습니다.
- Pending 메시지 회수 스케줄러를 추가했습니다.
- Admission 단계에서 Stream 적재 실패 시 Waiting Room으로 재등록하는 보정 로직을 추가했습니다.
- 레슨 신청/참가 테이블에 `(user_id, lesson_id)` 유니크 제약을 추가했습니다.
- Swagger API 태그를 정리했습니다.
   
## ✅ PR 유형
- [x] 버그 수정
- [x] 성능 개선
- [ ] 새로운 기능 추가
- [x] 코드 리팩토링
- [ ] 파일 혹은 폴더명 수정
- [ ] 문서 수정
- [x] 설정 변경

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?

## 🔗 관련 이슈
 - #234 

## 💬 기타 참고 사항
- Consumer 배치 실패 시 batch → chunk → individual fallback 흐름을 로컬에서 확인 완료